### PR TITLE
Add a 'masked' extension to handle masked input

### DIFF
--- a/mdp/__init__.py
+++ b/mdp/__init__.py
@@ -164,6 +164,7 @@ from classifier_node import (ClassifierNode, ClassifierCumulator)
 # import our modules
 import nodes
 import hinet
+import masked
 import parallel
 from test import test
 
@@ -199,6 +200,7 @@ __all__ = ['config',
            'get_extensions',
            'graph',
            'hinet',
+           'masked',
            'nodes',
            'parallel',
            'pca',

--- a/mdp/masked/__init__.py
+++ b/mdp/masked/__init__.py
@@ -1,0 +1,105 @@
+"""MDP extension to support masked node data.
+"""
+__docformat__ = "restructuredtext en"
+
+from ..utils import MaskedCovarianceMatrix
+from ..extension import ExtensionNode, activate_extension, deactivate_extension
+from ..signal_node import Node
+
+
+__all__ = [
+    'activate_masked',
+    'deactivate_masked',
+    ]
+
+_masked_active_global = False
+_masked_classes = []
+_masked_instances = []
+
+
+class MaskedCovarianceNode(ExtensionNode, Node):
+    """MDP extension for masked training data
+
+    Adapt a node to handle masked training data if:
+
+    a. the extension is activated in global mode,
+    b. the Node subclass is registered to be masked, or
+    c. the instance is registered to be masked
+
+    See `activate_masked`, `deactivate_masked`, and the `masked`
+    context manager to learn about how to activate the masked
+    mechanism and its options.
+    """
+
+    extension_name = 'masked'
+
+    def is_masked(self):
+        """Return True if the node is masked."""
+        global _masked_active_global
+        global _masked_classes
+        global _masked_instances
+        return (_masked_active_global
+                or self.__class__ in _masked_classes
+                or self in _masked_instances)
+
+    def set_instance_masked(self, active=True):
+        """Add or remove this instance from masked.
+
+        The global masked and class masked options still have priority over
+        the instance masked option.
+        """
+        # add to global dictionary
+        global _masked_instances
+        if active:
+            _masked_instances.append(self)
+        else:
+            if self in _masked_instances:
+                _masked_instances.remove(self)
+
+    def _new_covariance_matrix(self, *args, **kwargs):
+        if not self.is_masked():
+            return self._non_extension__new_covariance_matrix(*args, **kwargs)
+        return MaskedCovarianceMatrix(dtype=self.dtype)
+
+
+def activate_masked(masked_classes=None, masked_instances=None):
+    """Activate masked extension
+
+    By default, the masked is activated globally (i.e., for all
+    instances of Node). If masked_classes or masked_instances are
+    specified, the masked is activated only for those classes and
+    instances.
+
+    :Parameters:
+     masked_classes
+      A list of Node subclasses for which masked is activated.
+      Default value: None
+     masked_classes
+      A list of Node instances for which masked is activated.
+      Default value: None
+    """
+    global _masked_active_global
+    global _masked_classes
+    global _masked_instances
+
+    _masked_active_global = (masked_classes is None and
+                             masked_instances is None)
+
+    # active masked for specific classes and instances
+    if masked_classes is not None:
+        _masked_classes = list(masked_classes)
+    if masked_instances is not None:
+        _masked_instances = list(masked_instances)
+
+    activate_extension('masked')
+
+
+def deactivate_masked():
+    "De-activate masked extension"
+    global _masked_active_global
+    global _masked_classes
+    global _masked_instances
+    __masked_active_global = False
+    _masked_classes = []
+    _masked_instances = []
+    deactivate_extension('masked')

--- a/mdp/nodes/classifier_nodes.py
+++ b/mdp/nodes/classifier_nodes.py
@@ -379,9 +379,12 @@ class GaussianClassifier(ClassifierNode):
                    "datapoints (%d != %d)" % (len(labels), x.shape[0]))
             raise mdp.TrainingException(msg)
 
+    def _new_covariance_matrix(self):
+        return utils.CovarianceMatrix(dtype=self.dtype)
+
     def _update_covs(self, x, lbl):
         if lbl not in self._cov_objs:
-            self._cov_objs[lbl] = utils.CovarianceMatrix(dtype=self.dtype)
+            self._cov_objs[lbl] = self._new_covariance_matrix()
         self._cov_objs[lbl].update(x)
 
     def _train(self, x, labels):

--- a/mdp/nodes/em_nodes.py
+++ b/mdp/nodes/em_nodes.py
@@ -63,9 +63,13 @@ class FANode(mdp.Node):
         self.tol = tol
         self.max_cycles = max_cycles
         self.verbose = verbose
-        self._cov_mtx = CovarianceMatrix(dtype, bias=True)
+
+    def _new_covariance_matrix(self):
+        return CovarianceMatrix(dtype=self.dtype, bias=True)
 
     def _train(self, x):
+        if not hasattr(self, '_cov_mtx'):
+            self._cov_mtx = self._new_covariance_matrix()
         # update the covariance matrix
         self._cov_mtx.update(x)
 

--- a/mdp/nodes/fda_nodes.py
+++ b/mdp/nodes/fda_nodes.py
@@ -48,7 +48,6 @@ class FDANode(mdp.Node):
         # is deleted after training
         self._S_W = None
         # covariance matrix of the full data distribution
-        self._allcov = mdp.utils.CovarianceMatrix(dtype=self.dtype)
         self.means = {}  # maps class labels to the class means
         self.tlens = {}  # maps class labels to number of training points
         self.v = None  # transposed of the projection matrix
@@ -91,6 +90,9 @@ class FDANode(mdp.Node):
         self.means[label] += x.sum(axis=0)
         self.tlens[label] += x.shape[0]
 
+    def _new_covariance_matrix(self):
+        return mdp.utils.CovarianceMatrix(dtype=self.dtype)
+
     # Training step 2: compute the overall and within-class covariance
     # matrices and solve the FDA problem
 
@@ -100,6 +102,8 @@ class FDANode(mdp.Node):
             self._S_W = numx.zeros((self.input_dim, self.input_dim),
                                    dtype=self.dtype)
         # update the covariance matrix of all classes
+        if not hasattr(self, '_allcov'):
+            self._allcov = self._new_covariance_matrix()
         self._allcov.update(x)
         # if labels is a number, all x's belong to the same class
         if isinstance(labels, (list, tuple, numx.ndarray)):

--- a/mdp/nodes/pca_nodes.py
+++ b/mdp/nodes/pca_nodes.py
@@ -69,8 +69,6 @@ class PCANode(mdp.Node):
         self.var_rel = var_rel
         self.var_part = var_part
         self.reduce = reduce
-        # empirical covariance matrix, updated during the training phase
-        self._cov_mtx = CovarianceMatrix(dtype)
         # attributes that defined in stop_training
         self.d = None  # eigenvalues
         self.v = None  # eigenvectors, first index for coordinates
@@ -107,7 +105,12 @@ class PCANode(mdp.Node):
         """
         return self.explained_variance
 
+    def _new_covariance_matrix(self):
+        return CovarianceMatrix(dtype=self.dtype)
+
     def _train(self, x):
+        if not hasattr(self, '_cov_mtx'):
+            self._cov_mtx = self._new_covariance_matrix()
         # update the covariance matrix
         self._cov_mtx.update(x)
 

--- a/mdp/nodes/sfa_nodes.py
+++ b/mdp/nodes/sfa_nodes.py
@@ -77,12 +77,6 @@ class SFANode(Node):
         super(SFANode, self).__init__(input_dim, output_dim, dtype)
         self._include_last_sample = include_last_sample
 
-        # init two covariance matrices
-        # one for the input data
-        self._cov_mtx = CovarianceMatrix(dtype)
-        # one for the derivatives
-        self._dcov_mtx = CovarianceMatrix(dtype)
-
         # set routine for eigenproblem
         self._symeig = symeig
 
@@ -116,6 +110,9 @@ class SFANode(Node):
             raise TrainingException('Need at least 2 time samples to '
                                     'compute time derivative (%d given)'%s)
         
+    def _new_covariance_matrix(self):
+        return CovarianceMatrix(dtype=self.dtype)
+
     def _train(self, x, include_last_sample=None):
         """
         For the ``include_last_sample`` switch have a look at the
@@ -127,6 +124,12 @@ class SFANode(Node):
         last_sample_index = None if include_last_sample else -1
 
         # update the covariance matrices
+        if not hasattr(self, '_cov_mtx'):
+            # init two covariance matrices
+            # one for the input data
+            self._cov_mtx = self._new_covariance_matrix()
+            # one for the derivatives
+            self._dcov_mtx = self._new_covariance_matrix()
         self._cov_mtx.update(x[:last_sample_index, :])
         self._dcov_mtx.update(self.time_derivative(x))
 

--- a/mdp/nodes/xsfa_nodes.py
+++ b/mdp/nodes/xsfa_nodes.py
@@ -300,14 +300,18 @@ class ProjectionNode(mdp.Node):
 class NormalizeNode(mdp.PreserveDimNode):
     """Make input signal meanfree and unit variance"""
     def __init__(self, input_dim=None, output_dim=None, dtype=None):
-        self._cov_mtx = mdp.utils.CovarianceMatrix(dtype)
         super(NormalizeNode, self).__init__(input_dim, output_dim, dtype)
 
     @staticmethod
     def is_trainable():
         return True
 
+    def _new_covariance_matrix(self):
+        return CovarianceMatrix(dtype=self.dtype)
+
     def _train(self, x):
+        if not hasattr(self, '_cov_mtx'):
+            self._cov_mtx = self._new_covariance_matrix()
         self._cov_mtx.update(x)
 
     def _stop_training(self):

--- a/mdp/test/test_masked.py
+++ b/mdp/test/test_masked.py
@@ -1,0 +1,94 @@
+"""Test the masked extension"""
+
+import mdp
+
+
+def get_data():
+    data = mdp.numx.ma.array(mdp.numx.random.random((30, 10)), mask=False)
+    for i,j in [(2,1), (3,3), (12,0), (20,0)]:
+        data.mask[i,j] = True
+    return data
+
+
+def test_masked_extension():
+    """Test that the masked extension is working at the global level"""
+
+    node = mdp.nodes.PCANode()
+    data = get_data()
+
+    # activate the extension
+    mdp.masked.activate_masked()
+    assert mdp.get_active_extensions() == ['masked']
+
+    assert isinstance(node._new_covariance_matrix(),
+                      mdp.utils.MaskedCovarianceMatrix)
+    factors = node(data)
+
+    # after deactivation
+    mdp.masked.deactivate_masked()
+    assert mdp.get_active_extensions() == []
+    assert isinstance(node._new_covariance_matrix(),
+                      mdp.utils.CovarianceMatrix)
+
+
+def test_class_masked():
+    """Test the masked extension for individual classes"""
+    masked = mdp.nodes.PCANode()
+    notmasked = mdp.nodes.SFANode()
+    mdp.masked.activate_masked(masked_classes=[mdp.nodes.PCANode])
+    assert masked.is_masked()
+    assert not notmasked.is_masked()
+    mdp.masked.deactivate_masked()
+
+
+def test_class_masked_functionality():
+    """Test that masked extension classes really handle masked data"""
+    data = get_data()
+
+    # the node is not masked
+    node = mdp.nodes.PCANode()
+    mdp.masked.activate_masked(masked_classes=[mdp.nodes.SFANode])
+    assert isinstance(node._new_covariance_matrix(),
+                      mdp.utils.CovarianceMatrix)
+    factors = node(data)
+    mdp.masked.deactivate_masked()
+
+    # the node is masked
+    node = mdp.nodes.PCANode()
+    mdp.masked.activate_masked(masked_classes=[mdp.nodes.PCANode])
+    assert isinstance(node._new_covariance_matrix(),
+                      mdp.utils.MaskedCovarianceMatrix)
+    factors = node(data)
+    mdp.masked.deactivate_masked()
+
+
+def test_instance_masked():
+    """Test the masked extension for individual instances"""
+    masked = mdp.nodes.PCANode()
+    notmasked = mdp.nodes.PCANode()
+    mdp.masked.activate_masked(masked_instances=[masked])
+    assert masked.is_masked()
+    assert not notmasked.is_masked()
+    mdp.masked.deactivate_masked()
+
+
+def test_instance_masked_functionality():
+    """Test that masked extension instances really handle masked data"""
+    data = get_data()
+
+    # the node is not masked
+    node = mdp.nodes.PCANode()
+    othernode = mdp.nodes.PCANode()
+    mdp.masked.activate_masked(masked_instances=[othernode])
+    assert isinstance(node._new_covariance_matrix(),
+                      mdp.utils.CovarianceMatrix)
+    factors = node(data)
+    mdp.masked.deactivate_masked()
+
+    # the node is masked
+    node = mdp.nodes.PCANode()
+    mdp.masked.activate_masked(masked_instances=[node])
+    assert isinstance(node._new_covariance_matrix(),
+                      mdp.utils.MaskedCovarianceMatrix)
+    factors = node(data)
+    mdp.masked.deactivate_masked()

--- a/mdp/utils/__init__.py
+++ b/mdp/utils/__init__.py
@@ -21,8 +21,9 @@ except ImportError:
 
 from introspection import dig_node, get_node_size, get_node_size_str
 from quad_forms import QuadraticForm, QuadraticFormException
-from covariance import (CovarianceMatrix, DelayCovarianceMatrix,
-                        MultipleCovarianceMatrices,CrossCovarianceMatrix)
+from covariance import (CovarianceMatrix, MaskedCovarianceMatrix,
+                        DelayCovarianceMatrix, MultipleCovarianceMatrices,
+                        CrossCovarianceMatrix)
 from progress_bar import progressinfo
 from slideshow import (basic_css, slideshow_css, HTMLSlideShow,
                        image_slideshow_css, ImageHTMLSlideShow,
@@ -78,7 +79,8 @@ def svd(x, compute_uv = True):
     except _mdp.numx_linalg.LinAlgError, exc:
         raise SymeigException(str(exc))
 
-__all__ = ['CovarianceMatrix', 'DelayCovarianceMatrix','CrossCovarianceMatrix',
+__all__ = ['CovarianceMatrix', 'MaskedCovarianceMatrix',
+           'DelayCovarianceMatrix','CrossCovarianceMatrix',
            'MultipleCovarianceMatrices', 'QuadraticForm',
            'QuadraticFormException',
            'comb', 'cov2', 'dig_node', 'get_dtypes', 'get_node_size',


### PR DESCRIPTION
This doesn't actually seem to be substituting MaskedCovarianceMatrix
instances like it's supposed to, but I thought I'd post my work in
progress so others could chime in.

See the associated mailing list discussion for more details:

http://sourceforge.net/mailarchive/forum.php?thread_name=20130325121945.GI18933%40bio230.biologie.hu-berlin.de&forum_name=mdp-toolkit-users