### PR TITLE
Add wrapper function for exec

### DIFF
--- a/mdp/utils/templet.py
+++ b/mdp/utils/templet.py
@@ -179,6 +179,8 @@ class _TemplateBuilder(object):
                     code.append(s + self.emitpat % part)
         return '\n'.join(code)
 
+def _exec(code, globals, locals):
+    exec(code, globals, locals)
 
 class _TemplateMetaClass(type):
 
@@ -193,7 +195,7 @@ class _TemplateMetaClass(type):
         def expand(self, __dict = None, **kw):
             if __dict: kw.update([i for i in __dict.items() if i[0] not in kw])
             kw['self'] = self
-            exec(code, globals, kw)
+            _exec(code, globals, kw)
         return expand
 
     def __init__(cls, *args):


### PR DESCRIPTION
Old Python versions don't allow exec statement in nested functions:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "mdp/__init__.py", line 131, in <module>
    from . import utils
  File "mdp/utils/__init__.py", line 29, in <module>
    from .slideshow import (basic_css, slideshow_css, HTMLSlideShow,
  File "mdp/utils/slideshow.py", line 23, in <module>
    from . import templet
  File "mdp/utils/templet.py", line 196
    exec(code, globals, kw)
SyntaxError: unqualified exec is not allowed in function 'expand' it is a nested function
```

Different solution for #16.