### PR TITLE
SFANode update

### DIFF
--- a/mdp/hinet/layer.py
+++ b/mdp/hinet/layer.py
@@ -261,6 +261,12 @@ class CloneLayer(Layer):
         super(CloneLayer, self).__init__((node,) * n_nodes, dtype=dtype)
         self.node = node  # attribute for convenience
 
+    def _execute(self, x, *args, **kwargs):                                               ### VARUN's fix
+        n_samples = x.shape[0]                                                            ### VARUN's fix
+        x = x.reshape(n_samples * x.shape[1] / self.node.input_dim, self.node.input_dim)  ### VARUN's fix
+        y = self.node.execute(x)                                                          ### VARUN's fix
+        return y.reshape(n_samples, self.output_dim)                                      ### VARUN's fix
+
     def _stop_training(self, *args, **kwargs):
         """Stop training of the internal node."""
         if self.node.is_training():

--- a/mdp/nodes/sfa_nodes.py
+++ b/mdp/nodes/sfa_nodes.py
@@ -1,5 +1,5 @@
 
-#--------------------------------------------------------------------[ header ]
+#====================================================================[ header ]
 
 from builtins import range
 __docformat__ = "restructuredtext en"
@@ -8,11 +8,17 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 import mdp
-from mdp import numx, Node, NodeException, TrainingException
+from mdp import Node, NodeException, TrainingException
 from mdp.utils import (mult, pinv, CovarianceMatrix, QuadraticForm,
                        symeig, SymeigException)
 
-#-------------------------------------------------------------------[ SFANode ]
+#----------------------------------------------------------------------[ util ]
+
+def generateID():  # unique id generator (see _data_analysis)
+	generateID.i = 0 if 'i' not in generateID.__dict__ else generateID.i+1
+	return generateID.i
+
+#===================================================================[ SFANode ]
 
 class SFANode(Node):
     """Extract the slowly varying components from the input data.
@@ -78,13 +84,19 @@ class SFANode(Node):
     """
 
     def __init__(self, input_dim=None, output_dim=None, dtype=None,
-                 include_last_sample=True, use_svd=False, data_info='never'):
+                 include_last_sample=True, use_svd=False, always_analyse_data=False):
         """
-        - include_last_sample: see SFANode docstring or API doc [1].
-        - use_svd:   set to True if training throws SymeigException.
-        - data_info: produce additional information about the training data
-                     'never', 'always', or on 'fail' (only if training fails
-                     with SymeigException).
+        Extract the slowly varying components from the input data.
+
+        Args:
+            input_dim  (int): Dimensionality of the data going into the node.
+            output_dim (int): Dimensionality of the data leaving the node.
+            dtype     (type): Type information for the data (e.g. numpy.float64).
+            use_svd   (bool): Use SVD instead of the default symeig procedure to
+                              solve the SFA-internal eigenvalue problem.
+            include_last_sample: See SFANode docstring or API doc [1].
+            always_analyse_data: Produce additional information on the training
+                              data (always or only when training fails).
 
         [1] http://mdp-toolkit.sourceforge.net/api/mdp.nodes.SFANode-class.html
          """
@@ -93,26 +105,21 @@ class SFANode(Node):
 
         # init two covariance matrices
         # one for the input data
-        self._cov_mtx = CovarianceMatrix(dtype)
+        self._cov_mtx  = CovarianceMatrix(dtype)
         # one for the derivatives
         self._dcov_mtx = CovarianceMatrix(dtype)
 
         # set parameters for solving the eigenproblem
         self._symeig   = symeig
         self._use_svd  = use_svd
-        self._dat_info = data_info
+        self._analysis = always_analyse_data
 
         # SFA eigenvalues and eigenvectors, will be set after training
-        self.d = None
-        self.sf = None  # second index for outputs
-        self.avg = None
+        self.d     = None
+        self.sf    = None  # second index for outputs
+        self.avg   = None
         self._bias = None  # avg multiplied with sf
-        self.tlen = None
-
-    def time_derivative(self, x):
-        """Compute the linear approximation of the time derivative."""
-        # this is faster than a linear_filter or a weave-inline solution
-        return x[1:, :]-x[:-1, :]
+        self.tlen  = None
 
     def _set_range(self):
         if self.output_dim is not None and self.output_dim <= self.input_dim:
@@ -124,184 +131,13 @@ class SFANode(Node):
             self.output_dim = self.input_dim
         return rng
 
-    def _check_train_args(self, x, *args, **kwargs):
-        # check that we have at least 2 time samples to
-        # compute the update for the derivative covariance matrix
-        s = x.shape[0]
-        if  s < 2:
-            raise TrainingException('Need at least 2 time samples to '
-                                    'compute time derivative (%d given)'%s)
-
-    def _train(self, x, include_last_sample=None):
-        """
-        For the ``include_last_sample`` switch have a look at the
-        SFANode class docstring.
-        """
-        if include_last_sample is None:
-            include_last_sample = self._include_last_sample
-        # works because x[:None] == x[:]
-        last_sample_index = None if include_last_sample else -1
-
-        # update the covariance matrices
-        self._cov_mtx.update(x[:last_sample_index, :])
-        self._dcov_mtx.update(self.time_derivative(x))
-
-    def _data_plot_(self, x, sub_pos, title='', arg_sort=False, style='dots'):
-        """
-        Helper function for _provide_data_help_. This plots the various subplots
-        produced by _provide_data_help_.
-        """
-        # plot and axis setup
-        ax = plt.subplot( sub_pos[0], sub_pos[1], sub_pos[2] )
-        if title is not '': ax.set_title( title )
-        x_rng    = np.arange( len(x) )
-        x_labels = x_rng
-        # sort data by dimension (default) or value (arg_sort)
-        if arg_sort:
-            sort = np.argsort( x )
-            x_labels = x_labels[sort]
-            x = x[sort]
-        # plot
-        if style is 'bars':
-            plt.bar( x_rng, x, align='center' )
-        elif style is 'dots':
-            plt.plot( x, 'o' )
-        # ticks and tick labels
-        if len(x) <= 50: plt.xticks( x_rng )
-        ax.set_xticklabels( x_labels )
-        ax.set_xlim( (-1,len(x_rng)) )
-
-    def _provide_data_help(self, full=False ):
-        """
-        This function provides some basic data analysis of the used training
-        data plus more a verbose error message if training the SFANode fails.
-
-        - full: If False, additional information on the training data is given.
-                If True, additional reasoning is given why this might be needed.
-        """
-
-        # plot some basic data analysis of the (presumably failed) training data
-        print '\t..analysing training data..'
-        plt.clf()
-        # plot training data variance per dimension
-        self._data_plot_(np.diagonal(self.cov_mtx), (3, 2, 1), 'Variance per dimension')
-        self._data_plot_(np.diagonal(self.cov_mtx), (3, 2, 2), 'Dimensions by Variance', arg_sort=True)
-        # plot training data slowness/delta values per dimension
-        self._data_plot_(np.diagonal(self.dcov_mtx), (3, 2, 3), 'Slowness per dimension')
-        self._data_plot_(np.diagonal(self.dcov_mtx), (3, 2, 4), 'Dimensions by slowness', True)
-        # plot eigenvalue spectrum
-        _, s, _ = np.linalg.svd( self.cov_mtx )
-        self._data_plot_(s, (3, 2, 5), 'Eigenvalue spectrum')
-        # clean up and save plot
-        plt.tight_layout()
-        plt.savefig( 'SFANode data info.png' )
-        print '\t..training data information plotted..'
-
-        # print optional additional information about the SymeigException
-        err = "This usually happens if there are redundancies in the (expanded) training data.\n" + \
-              "There are several ways to deal with this issue:\n\n" + \
-              "   - Use more data.\n\n" + \
-              "   - Add noise to the data. This can be done by slotting an additional NoiseNode\n\n" + \
-              "     in front of a troublesome SFANode. Noise levels do not have to be high.\n\n" + \
-              "   - Run training data through PCA. This can be done by slotting an additional\n\n" + \
-              "     PCA node in front of the troublesome SFANode. Use the PCA node to discard\n\n" + \
-              "     dimensions within your data with lower variance." + \
-              "   - [ RECOMMENDED ] Use SVD by setting the SFANode flag use_svd to True. This\n\n" + \
-              "     solves the internal SFA eigenvalue problem by using two instances of singular\n\n" + \
-              "     value decomposition (SVD) instead of the default behavior of using the\n\n" + \
-              "     systems's symeig() routine to solve a single, generalized eigenvalue problem.\n\n" + \
-              "     Using SVD is slightly more expensive but more robust.\n\n"
-        return err if full else ''
-
-    def _svd_solver(self, rng):
-        """
-        Alternative routine to solve the SFA eigenvalue issue. This can be used
-        in case the normal symeig() call in _stop_training() throws the common
-        SymeigException ('Covariance matrices may be singular').
-        For details on the used algorithm see:
-            http://www.geo.tuwien.ac.at/downloads/tm/svd.pdf (section 0.3.2)
-        """
-
-        U, s, _ = np.linalg.svd(self.cov_mtx)
-        X1 = np.dot(U, np.diag(1.0 / s ** 0.5))
-        X2, _, _ = np.linalg.svd(np.dot(X1.T, np.dot(self.dcov_mtx, X1)))
-        E = np.dot(X1, X2)
-        e = np.dot(E.T, np.dot(self.dcov_mtx, E)).diagonal()
-
-        e = e[::-1]      # SVD delivers the eigenvalues sorted in reverse (compared to symeig). Thus
-        E = E.T[::-1].T  # we manually reverse the array/matrix storing the eigenvalues/vectors.
-
-        if rng is None:
-            self.d, self.sf = e, E
-        else:
-            self.d, self.sf = e[rng[0] - 1:rng[1]], E[:, rng[0] - 1:rng[1]]
-
-    def _stop_training(self, debug=False):
-
-        # request the covariance matrices and clean up
-        self.cov_mtx, self.avg, self.tlen = self._cov_mtx.fix()
-        del self._cov_mtx
-
-        # do not center around the mean:
-        # we want the second moment matrix (centered about 0) and
-        # not the second central moment matrix (centered about the mean), i.e.
-        # the covariance matrix
-        self.dcov_mtx, self.davg, self.dtlen = self._dcov_mtx.fix(center=False)
-        del self._dcov_mtx
-
-        if self._dat_info is 'always': self._provide_data_help()
-
-        rng = self._set_range()
-
-        ####################################################################### EIG
-
-        #### solve the generalized eigenvalue problem
-        # the eigenvalues are already ordered in ascending order
-        if not self._use_svd:
-            try:
-                self.d, self.sf = self._symeig(self.dcov_mtx, self.cov_mtx,
-                                         range=rng, overwrite=(not debug))
-                d = self.d
-                # check that we get only *positive* eigenvalues
-                if d.min() < 0:
-                    err_msg = ("Got negative eigenvalues: %s."
-                               " You may either set output_dim to be smaller,"
-                               " or prepend the SFANode with a PCANode(reduce=True)"
-                               " or PCANode(svd=True)"% str(d))
-                    raise NodeException(err_msg)
-
-            except SymeigException as exception:
-                errstr = str(exception)+"\n Covariance matrices may be singular."
-                if self._dat_info is 'fail':
-                    errstr += self._provide_data_help( full=True )
-                raise NodeException(errstr)
-
-        else:
-            self._svd_solver( rng )  # sets self.d and self.sf
-
-        ####################################################################### EIG
-
-        if not debug:
-            # delete covariance matrix if no exception occurred
-            del self.cov_mtx
-            del self.dcov_mtx
-
-        # store bias
-        self._bias = mult(self.avg, self.sf)
-
-    def _execute(self, x, n=None):
-        """Compute the output of the slowest functions.
-        If 'n' is an integer, then use the first 'n' slowest components."""
-        if n:
-            sf = self.sf[:, :n]
-            bias = self._bias[:n]
-        else:
-            sf = self.sf
-            bias = self._bias
-        return mult(x, sf) - bias
-
     def _inverse(self, y):
         return mult(y, pinv(self.sf)) + self.avg
+
+    def time_derivative(self, x):
+        """Compute the linear approximation of the time derivative."""
+        # this is faster than a linear_filter or a weave-inline solution
+        return x[1:, :]-x[:-1, :]
 
     def get_eta_values(self, t=1):
         """Return the eta values of the slow components learned during
@@ -331,8 +167,199 @@ class SFANode(Node):
         """
         if self.is_training():
             self.stop_training()
-        return self._refcast(t / (2 * numx.pi) * numx.sqrt(self.d))
+        return self._refcast(t / (2 * np.pi) * np.sqrt(self.d))
 
+    #--------------------------------------------------------------[ training ]
+
+    def _check_train_args(self, x, *args, **kwargs):
+        # check that we have at least 2 time samples to
+        # compute the update for the derivative covariance matrix
+        s = x.shape[0]
+        if  s < 2:
+            raise TrainingException('Need at least 2 time samples to '
+                                    'compute time derivative (%d given)'%s)
+
+    def _train(self, x, include_last_sample=None):
+        """
+        For the ``include_last_sample`` switch have a look at the
+        SFANode class docstring.
+        """
+        if include_last_sample is None:
+            include_last_sample = self._include_last_sample
+        # works because x[:None] == x[:]
+        last_sample_index = None if include_last_sample else -1
+
+        # update the covariance matrices
+        self._cov_mtx.update(x[:last_sample_index, :])
+        self._dcov_mtx.update(self.time_derivative(x))
+
+    def _stop_training(self, debug=False):
+
+        # request the covariance matrices and clean up
+        self.cov_mtx, self.avg, self.tlen = self._cov_mtx.fix()
+        del self._cov_mtx
+
+        # do not center around the mean:
+        # we want the second moment matrix (centered about 0) and
+        # not the second central moment matrix (centered about the mean), i.e.
+        # the covariance matrix
+        self.dcov_mtx, self.davg, self.dtlen = self._dcov_mtx.fix(center=False)
+        del self._dcov_mtx
+
+        rng = self._set_range()
+
+        ####################################################################### EIG
+
+        #### solve the generalized eigenvalue problem
+        # the eigenvalues are already ordered in ascending order
+        if not self._use_svd:
+            try:
+                self.d, self.sf = self._symeig(self.dcov_mtx, self.cov_mtx,
+                                         range=rng, overwrite=(not debug))
+                d = self.d
+                # check that we get only *positive* eigenvalues
+                if d.min() < 0:
+                    err_msg = ("Got negative eigenvalues: %s."
+                               " You may either set output_dim to be smaller,"
+                               " or prepend the SFANode with a PCANode(reduce=True)"
+                               " or PCANode(svd=True)"% str(d))
+                    raise NodeException(err_msg)
+
+            except SymeigException as exception:
+                errstr  = str(exception)+"\n Covariance matrices may be singular."
+                errstr += self._data_fail_msg()  # offer some additional information on this issue
+                self._data_analysis()            # and print some information about the training set
+                raise NodeException(errstr)
+
+        else:
+            self._svd_solver( rng )  # sets self.d and self.sf
+
+        ####################################################################### EIG
+
+        if not debug:
+            # delete covariance matrix if no exception occurred
+            del self.cov_mtx
+            del self.dcov_mtx
+
+        # store bias
+        self._bias = mult(self.avg, self.sf)
+
+        # plot some statistics of the training data (optional)
+        if self._analysis: self._data_analysis()
+
+    def _execute(self, x, n=None):
+        """Compute the output of the slowest functions.
+        If 'n' is an integer, then use the first 'n' slowest components."""
+        if n:
+            sf = self.sf[:, :n]
+            bias = self._bias[:n]
+        else:
+            sf = self.sf
+            bias = self._bias
+        return mult(x, sf) - bias
+
+    def _svd_solver(self, rng):
+        """
+        Alternative routine to solve the SFA eigenvalue issue. This can be used
+        in case the normal symeig() call in _stop_training() throws the common
+        SymeigException ('Covariance matrices may be singular').
+
+        For details on the used algorithm see:
+            http://www.geo.tuwien.ac.at/downloads/tm/svd.pdf (section 0.3.2)
+        """
+
+        U, s, _ = np.linalg.svd(self.cov_mtx)
+        X1 = np.dot(U, np.diag(1.0 / s ** 0.5))
+        X2, _, _ = np.linalg.svd(np.dot(X1.T, np.dot(self.dcov_mtx, X1)))
+        E = np.dot(X1, X2)
+        e = np.dot(E.T, np.dot(self.dcov_mtx, E)).diagonal()
+
+        e = e[::-1]      # SVD delivers the eigenvalues sorted in reverse (compared to symeig). Thus
+        E = E.T[::-1].T  # we manually reverse the array/matrix storing the eigenvalues/vectors.
+
+        if rng is None:
+            self.d, self.sf = e, E
+        else:
+            self.d, self.sf = e[rng[0] - 1:rng[1]], E[:, rng[0] - 1:rng[1]]
+
+    #-------------------------------------------------------------[ debugging ]
+
+    def _data_fail_msg(self):
+        """
+        This methods provides additional information in case _stop_training()
+        runs into a singular matrix and cannot continue. Since this is a common
+        problem, this message expands on the issue and offers different ways to
+        solve it.
+
+        Returns:
+            string: Additional string to be appended to the default error.
+        """
+        return "This usually happens if there are redundancies in the (expanded) training data.\n" + \
+               " There are several ways to deal with this issue:\n\n" + \
+               "   - Use more data.\n\n" + \
+               "   - Add noise to the data. This can be done by slotting an additional NoiseNode\n" + \
+               "     in front of a troublesome SFANode. Noise levels do not have to be high.\n\n" + \
+               "   - Run training data through PCA. This can be done by slotting an additional\n" + \
+               "     PCA node in front of the troublesome SFANode. Use the PCA node to discard\n" + \
+               "     dimensions within your data with lower variance.\n\n" + \
+               "   - [ RECOMMENDED ] Use SVD by setting the SFANode flag use_svd to True. This\n" + \
+               "     solves the internal SFA eigenvalue problem by using two instances of singular\n" + \
+               "     value decomposition (SVD) instead of the default behavior of using the\n" + \
+               "     systems's symeig() routine to solve a single, generalized eigenvalue problem.\n" + \
+               "     Using SVD is slightly more expensive but more robust.\n"
+
+    def _data_analysis(self):
+        """
+        Function to provide basic data analysis of the used training data. It
+        creates a plot depicting the variance and slowness per signal, as well
+        as the eigenvalue spectrum of the training data.
+        """
+
+        plt.clf()
+
+        self._data_analysis_plotter(np.diagonal(self.cov_mtx),  (3, 2, 1), 'Variance per dimension')
+        self._data_analysis_plotter(np.diagonal(self.cov_mtx),  (3, 2, 2), 'Dimensions by Variance', arg_sort=True)
+        self._data_analysis_plotter(np.diagonal(self.dcov_mtx), (3, 2, 3), 'Slowness per dimension')
+        self._data_analysis_plotter(np.diagonal(self.dcov_mtx), (3, 2, 4), 'Dimensions by slowness', arg_sort=True)
+
+        _, s, _ = np.linalg.svd( self.cov_mtx )
+        self._data_analysis_plotter(s, (3, 2, 5), 'Eigenvalue spectrum')
+
+        plt.tight_layout()
+        plt.savefig( 'SFANode['+str(generateID())+'] training data analysis.png' )
+
+    def _data_analysis_plotter(self, x, sub_pos, title='', arg_sort=False, style='dots'):
+        """
+        Helper function for _data_analysis(). Here the actual (sub) plots are
+        being generated.
+
+        Args:
+            x (numerical array): 1D array of data to be plotted.
+            sub_pos ((int,int,int) tupel): Position of the sub plot in the overall plot.
+            arg_sort (bool): Sort by dimension (0..n) [False] or by value per dimension [True].
+            style ('dots'/'bars'): Plot data as set of 'dots' or 'bars'.
+        """
+        # plot and axis setup
+        ax = plt.subplot( sub_pos[0], sub_pos[1], sub_pos[2] )
+        if title is not '': ax.set_title( title )
+        x_rng    = np.arange( len(x) )
+        x_labels = x_rng
+        # sort data by dimension (default) or value (arg_sort)
+        if arg_sort:
+            sort = np.argsort( x )
+            x_labels = x_labels[sort]
+            x = x[sort]
+        # plot
+        if style is 'bars':
+            plt.bar( x_rng, x, align='center' )
+        elif style is 'dots':
+            plt.plot( x, 'o' )
+        # ticks and tick labels
+        if len(x) <= 50: plt.xticks( x_rng )
+        ax.set_xticklabels( x_labels )
+        ax.set_xlim( (-1,len(x_rng)) )
+
+#==================================================================[ SFA2Node ]
 
 class SFA2Node(SFANode):
     """Get an input signal, expand it in the space of
@@ -401,7 +428,7 @@ class SFA2Node(SFANode):
         c = -mult(self.avg, sf)
         n = self.input_dim
         f = sf[:n]
-        h = numx.zeros((n, n), dtype=self.dtype)
+        h = np.zeros((n, n), dtype=self.dtype)
         k = n
         for i in range(n):
             for j in range(n):
@@ -415,27 +442,3 @@ class SFA2Node(SFANode):
                     h[i, j] = h[j, i]
 
         return QuadraticForm(h, f, c, dtype=self.dtype)
-
-
-
-### old weave inline code to perform the time derivative
-
-# weave C code executed in the function SfaNode.time_derivative
-## _TDERIVATIVE_1ORDER_CCODE = """
-##   for( int i=0; i<columns; i++ ) {
-##     for( int j=0; j<rows-1; j++ ) {
-##       deriv(j,i) = x(j+1,i)-x(j,i);
-##     }
-##   }
-## """
-
-# it was called like that:
-## def time_derivative(self, x):
-##     rows = x.shape[0]
-##     columns = x.shape[1]
-##     deriv = numx.zeros((rows-1, columns), dtype=self.dtype)
-
-##     weave.inline(_TDERIVATIVE_1ORDER_CCODE,['rows','columns','deriv','x'],
-##                  type_factories = weave.blitz_tools.blitz_type_factories,
-##                  compiler='gcc',extra_compile_args=['-O3']);
-##     return deriv

--- a/mdp/utils/covariance.py
+++ b/mdp/utils/covariance.py
@@ -3,10 +3,10 @@ from builtins import object
 import mdp
 import warnings
 
-import sys                                                                       # CUDA cov update
-import ctypes                                                                    # CUDA cov update
-import numpy as np                                                               # CUDA cov update
-libcublas = ctypes.cdll.LoadLibrary('/local/work/cuda_mdp_module/libmodule.so')  # CUDA cov update
+
+import ctypes                                                                 # CUDA cov update
+import numpy as np                                                            # CUDA cov update
+libcublas = ctypes.cdll.LoadLibrary( mdp.__path__[0]+'/utils/libmodule.so' )  # CUDA cov update
 
 # import numeric module (scipy, Numeric or numarray)
 numx = mdp.numx

--- a/mdp/utils/covariance.py
+++ b/mdp/utils/covariance.py
@@ -3,11 +3,6 @@ from builtins import object
 import mdp
 import warnings
 
-
-import ctypes                                                                 # CUDA cov update
-import numpy as np                                                            # CUDA cov update
-libcublas = ctypes.cdll.LoadLibrary( mdp.__path__[0]+'/utils/libmodule.so' )  # CUDA cov update
-
 # import numeric module (scipy, Numeric or numarray)
 numx = mdp.numx
 
@@ -92,23 +87,7 @@ class CovarianceMatrix(object):
         # update the covariance matrix, the average and the number of
         # observations (try to do everything inplace)
 
-        ################################################ default cov update ###
-        """self._cov_mtx += mdp.utils.mult(x.T, x)"""
-        ################################################### CUDA cov update ###
-        tmp = np.zeros( (x.shape[1],x.shape[1]), dtype=np.float32 )
-
-        if x.flags['F_CONTIGUOUS']: # data given in Fortran's column major order
-            libcublas.cublas2ndMoment_F( x.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-                                         x.shape[0], x.shape[1],
-                                         tmp.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-                                         1 )
-        elif x.flags['C_CONTIGUOUS']: # data given in c's row major order
-            libcublas.cublas2ndMoment( x.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-                                       x.shape[0], x.shape[1],
-                                       tmp.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-                                       1 )
-        self._cov_mtx += tmp
-        #######################################################################
+        self._cov_mtx += mdp.utils.mult(x.T, x)
 
         self._avg += x.sum(axis=0)
         self._tlen += x.shape[0]

--- a/mdp/utils/covariance.py
+++ b/mdp/utils/covariance.py
@@ -3,6 +3,11 @@ from builtins import object
 import mdp
 import warnings
 
+import sys                                                                       # CUDA cov update
+import ctypes                                                                    # CUDA cov update
+import numpy as np                                                               # CUDA cov update
+libcublas = ctypes.cdll.LoadLibrary('/local/work/cuda_mdp_module/libmodule.so')  # CUDA cov update
+
 # import numeric module (scipy, Numeric or numarray)
 numx = mdp.numx
 
@@ -86,7 +91,25 @@ class CovarianceMatrix(object):
         x = mdp.utils.refcast(x, self._dtype)
         # update the covariance matrix, the average and the number of
         # observations (try to do everything inplace)
-        self._cov_mtx += mdp.utils.mult(x.T, x)
+
+        ################################################ default cov update ###
+        """self._cov_mtx += mdp.utils.mult(x.T, x)"""
+        ################################################### CUDA cov update ###
+        tmp = np.zeros( (x.shape[1],x.shape[1]), dtype=np.float32 )
+
+        if x.flags['F_CONTIGUOUS']: # data given in Fortran's column major order
+            libcublas.cublas2ndMoment_F( x.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                                         x.shape[0], x.shape[1],
+                                         tmp.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                                         1 )
+        elif x.flags['C_CONTIGUOUS']: # data given in c's row major order
+            libcublas.cublas2ndMoment( x.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                                       x.shape[0], x.shape[1],
+                                       tmp.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+                                       1 )
+        self._cov_mtx += tmp
+        #######################################################################
+
         self._avg += x.sum(axis=0)
         self._tlen += x.shape[0]
 


### PR DESCRIPTION
This Pull Request includes additional functionality of the basic SFANode:

- **SFANode.__init__ arguments**
  - *use_svd:* Switch to use SVD-based solution to the internal eigenvalue problem instead of the default call to `symeig()`. **Default:** False.
  - *always_analyse_data:* If `_stop_training()` fails with the common "singular values" exception, the code will now produce a simple plot that depicts some basic data analysis (see below). If set to True, this will always happen; when set to False it will only trigger the analysis when the exception is thrown. **Default:** False.

- **SFANode._svd_solver()**
  - Alternative method to solving the eigenvalue problem at the heart of SFA. See [1] for details on the implemented algorithm.
  - The SVD based method requires a bit more memory and slightly more time than the default method. Profiling was done with a simple script found [here](https://pastebin.com/jd74rNPc). Timings can be seen below [2]; memory use can be seen [here](http://i.imgur.com/ttqT1l9.png). (Profiling test case used a random 2k x 2k matrix as `self.cov_mtx` and `self.dcov_mtx` and ran ten times through the respective processes.) The script can quickly be extended to test different methods of solving the internal eigenvalue issue.

- **Debug additions**
  - Three utility functions to provide more information in case `_stop_training()` fails with the common "singluar values" exception: `_data_fail_msg()`; `_data_analysis()`; and `_data_analysis_plotter()`.
  - `_data_fail_msg()` merely returns a more verbose error message if the exception is thrown.
  - `_data_analysis()` produces a plot depicting variance and slowness per signal, as well as the eigenvalue spectrum. it uses `_data_analysis_plotter()` as an utility function.
  - `_data_analysis_plotter()` creates the sub plots for the overall plot created in `_data_analysis()`.

**[1]** http://www.geo.tuwien.ac.at/downloads/tm/svd.pdf (section 0.3.2)
**[2]** SVD and symeig timings:
```
$ ./run_profiling.sh 
+ mprof run --python python2 profiling.py
mprof: Sampling memory every 0.1s
running as a Python program...

Using numpy version 1.12.0 (@ /home/fabian/.local/lib/python2.7/site-packages/numpy)
Using mdp version 3.5 (@ /local/work/MDP-3.5/mdp)
Generating garbage..
Storing garbage in memmap..
Garbage ready for use.

Running symeig_test
    Run 1/10.. done. (11.3755309582)
    Run 2/10.. done. (11.335201025)
    Run 3/10.. done. (11.3295040131)
    Run 4/10.. done. (11.4707131386)
    Run 5/10.. done. (11.4013779163)
    Run 6/10.. done. (11.3865709305)
    Run 7/10.. done. (11.4483189583)
    Run 8/10.. done. (11.6087400913)
    Run 9/10.. done. (11.4543762207)
    Run 10/10.. done. (11.4626760483)
    Avg. time (excluding first run): 11.4330531491
    Min. time (excluding first run): 11.3295040131

Running svd_test
    Run 1/10.. done. (11.5337908268)
    Run 2/10.. done. (14.9500858784)
    Run 3/10.. done. (17.1977508068)
    Run 4/10.. done. (11.8235440254)
    Run 5/10.. done. (12.585725069)
    Run 6/10.. done. (11.9705069065)
    Run 7/10.. done. (13.4548399448)
    Run 8/10.. done. (17.0780851841)
    Run 9/10.. done. (13.7380120754)
    Run 10/10.. done. (12.5583138466)
    Avg. time (excluding first run): 13.9285404152
    Min. time (excluding first run): 11.8235440254
All done.
+ mprof plot
Using last profile data.
```