### PR TITLE
Fix symeig_semidefinite for Python 3

### DIFF
--- a/mdp/utils/symeig_semidefinite.py
+++ b/mdp/utils/symeig_semidefinite.py
@@ -55,7 +55,7 @@ ldl (solves by applying LDL / Cholesky decomposition for indefinite matrices)
 
 import mdp
 from mdp import numx
-from _symeig import SymeigException
+from ._symeig import SymeigException
 
 
 def symeig_semidefinite_reg(
@@ -103,7 +103,8 @@ def symeig_semidefinite_reg(
     eg, ev = mdp.utils.symeig(A, B, True, turbo, None, type, overwrite)
 
     Bflat[idx] = diag_tmp
-    m = numx.absolute(numx.sqrt(numx.sum(ev * mdp.utils.mult(B, ev), 0))-1)
+    m = numx.absolute(numx.sqrt(numx.absolute(
+            numx.sum(ev * mdp.utils.mult(B, ev), 0)))-1)
     off = 0
     # In theory all values in m should be close to one or close to zero.
     # So we use the mean of these values as threshold to distinguish cases:


### PR DESCRIPTION
Fix symeig_semidefinite for Python 3
and renamed ``_symeig._assert_eigenvalues_real_and_positive`` to ``_symeig._assert_eigenvalues_real``, because it actually does not check for positivity, so the original name was misleading. This is internal API of _symeig.py and thus should not break anything (and tests confirm it doesn't). Ther was another issue with Python3 and ``_symeig`` that could have lead to nan values in reults instead of raising an exception. This might be due to older NumPy, older SciPy or Python3 (cannot really tell), but it is however fixed now by an explicit check.