### PR TITLE
GSFA and iGSFA nodes

### DIFF
--- a/mdp/nodes/__init__.py
+++ b/mdp/nodes/__init__.py
@@ -26,6 +26,7 @@ from .jade import JADENode
 from .nipals import NIPALSNode
 from .lle_nodes import LLENode, HLLENode
 from .xsfa_nodes import XSFANode, NormalizeNode
+from .gsfa_nodes import GSFANode, iGSFANode
 
 # import internals for use in test_suites
 from .misc_nodes import OneDimensionalHitParade as _OneDimensionalHitParade
@@ -38,7 +39,7 @@ from .stats_nodes_online import OnlineCenteringNode, OnlineTimeDiffNode
 
 __all__ = ['PCANode', 'WhiteningNode', 'NIPALSNode', 'FastICANode',
            'CuBICANode', 'TDSEPNode', 'JADENode', 'SFANode', 'SFA2Node',
-           'ISFANode', 'XSFANode', 'FDANode', 'FANode', 'RBMNode',
+           'ISFANode', 'XSFANode', 'GSFANode', 'iGSFANode', 'FDANode', 'FANode', 'RBMNode',
            'RBMWithLabelsNode', 'GrowingNeuralGasNode', 'LLENode', 'HLLENode',
            'LinearRegressionNode', 'QuadraticExpansionNode',
            'PolynomialExpansionNode', 'RBFExpansionNode','GeneralExpansionNode',
@@ -95,6 +96,7 @@ utils.fixup_namespace(__name__, __all__ + ['ICANode'],
                        'nipals',
                        'lle_nodes',
                        'xsfa_nodes',
+                       'gsfa_nodes',
                        'convolution_nodes',
                        'shogun_svm_classifier',
                        'svm_classifiers',

--- a/mdp/nodes/gsfa_nodes.py
+++ b/mdp/nodes/gsfa_nodes.py
@@ -1,0 +1,2106 @@
+######################################################################################################################
+# gsfa_nodes: This module implements the Graph-Based SFA Node (GSFANode) and the Information-Preserving GSFA Node    #
+#             (iGSFANode). This file belongs to the Cuicuilco framework                                              #
+#                                                                                                                    #
+# See the following publications for details on GSFA and iGSFA:                                                      #
+# * Escalante-B A.-N., Wiskott L, "How to solve classification and regression problems on high-dimensional data with #
+# a supervised extension of Slow Feature Analysis". Journal of Machine Learning Research 14:3683-3719, 2013          #
+# * Escalante-B., A.-N. and Wiskott, L., "Improved graph-based {SFA}: Information preservation complements the       #
+# slowness principle", e-print arXiv:1601.03945, http://arxiv.org/abs/1601.03945, 2017                               #
+#                                                                                                                    #
+# Examples of using GSFA and iGSFA are provided at the end of the file                                               #
+#                                                                                                                    #
+# By Alberto Escalante. Alberto.Escalante@ini.ruhr-uni-bochum.de                                                     #
+# Ruhr-University-Bochum, Institute for Neural Computation, Group of Prof. Dr. Wiskott                               #
+######################################################################################################################
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+import numpy
+import scipy
+import scipy.optimize
+import sys
+
+import mdp
+# from mdp.nodes.sfa_nodes import SFANode
+from mdp.utils import (mult, symeig, pinv, CovarianceMatrix, SymeigException)
+from mdp.nodes import GeneralExpansionNode
+
+# TODO: Apparently one must derive from the original mdp.Node, not from mdp.nodes.SFANode
+class GSFANode(mdp.Node):
+    """ This node implements "Graph-Based SFA (GSFA)", which is the main component of hierarchical GSFA (HGSFA).
+
+    For further information, see: Escalante-B A.-N., Wiskott L, "How to solve classification and regression
+    problems on high-dimensional data with a supervised extension of Slow Feature Analysis". Journal of Machine
+    Learning Research 14:3683-3719, 2013
+    """
+    def __init__(self, input_dim=None, output_dim=None, dtype=None, block_size=None, train_mode=None, verbose=False):
+        """Initializes the GSFA node, which is a subclass of the SFA node.
+
+        The parameters block_size and train_mode are not necessary and it is recommended to skip them here and
+        provide them as parameters to the train method.
+        See the _train method for details.
+        """
+        super(GSFANode, self).__init__(input_dim, output_dim, dtype)
+        self.pinv = None
+        self.block_size = block_size
+        self.train_mode = train_mode
+        self.verbose = verbose
+        self._symeig = symeig
+        self._covdcovmtx = CovDCovMatrix()
+        # List of parameters that are accepted by train()
+        self.list_train_params = ["train_mode", "block_size", "node_weights", "edge_weights", "verbose"]
+
+
+    def _train(self, x, block_size=None, train_mode=None, node_weights=None, edge_weights=None,
+                                 verbose=None):
+        """ This is the main training function of GSFA.
+        
+        x: training data (each sample is a row)
+
+        The semantics of the remaining parameters depends on the training mode (train_mode) parameter
+        in order to train as in standard SFA:
+            set train_mode="regular" (the scale of the features should be corrected afterwards)
+        in order to train using the clustered graph:
+            set train_mode="clustered". The cluster size is given by block_size (integer). Variable cluster sizes are 
+            possible if block_size is a list of integers. Samples belonging to the same class should be adjacent.
+        in order to train for classification:
+            set train_mode=("classification", labels, weight), where labels is an array with the class information and
+            weight is a scalar value (e.g., 1.0).
+        in order to train for regression:
+            set train_mode=("serial_regression#", labels, weight), where # is an integer that specifies the block size
+            used by a serial graph, labels is an array with the label information and weight is a scalar value.
+        in order to train using a graph without edges:
+            set train_mode="unlabeled".
+        in order to train using the serial graph:
+            set train_mode="serial", and use block_size (integer) to specify the group size. 
+        in order to train using the mixed graph:
+            set train_mode="mixed", and use block_size (integer) to specify the group size.           
+        in order to train using an arbitrary user-provided graph:
+            set train_mode="graph", specify the node_weights (numpy 1D array), and the
+            edge_weights (numpy 2D array).
+        """
+        if train_mode is None:
+            train_mode = self.train_mode
+        if verbose is None:
+           verbose = self.verbose
+        if block_size is None:
+            if verbose:
+                print("parameter block_size was not provided, using default value self.block_size")
+            block_size = self.block_size
+
+        self.set_input_dim(x.shape[1])
+
+        if verbose:
+            print("train_mode=", train_mode)
+
+        if isinstance(train_mode, list):
+            train_modes = train_mode
+        else:
+            train_modes = [train_mode]
+
+        for train_mode in train_modes:
+            if isinstance(train_mode, tuple):
+                method = train_mode[0]
+                labels = train_mode[1]
+                weight = train_mode[2]
+                if method == "classification":
+                    if verbose:
+                        print("update classification")
+                    ordering = numpy.argsort(labels)
+                    x2 = x[ordering, :]
+                    unique_labels = numpy.unique(labels)
+                    unique_labels.sort()
+                    block_sizes = []
+                    for label in unique_labels:
+                        block_sizes.append((labels == label).sum())
+                    self._covdcovmtx.update_clustered(x2, block_sizes=block_sizes, weight=weight)
+                elif method.startswith("serial_regression"):
+                    block_size = int(method[len("serial_regression"):])
+                    if verbose:
+                        print("update serial_regression, block_size=", block_size)
+                    ordering = numpy.argsort(labels)
+                    x2 = x[ordering, :]
+                    self._covdcovmtx.update_serial(x2, block_size=block_size, weight=weight)
+                else:
+                    er = "method unknown: %s" % (str(method))
+                    raise Exception(er)
+            else:
+                if train_mode == 'unlabeled':
+                    if verbose:
+                        print("update_unlabeled")
+                    self._covdcovmtx.update_unlabeled(x, weight=0.00015)  # Warning, set this weight appropriately!
+                elif train_mode == "regular":
+                    if verbose:
+                        print("update_regular")
+                    self._covdcovmtx.update_regular(x, weight=1.0)
+                elif train_mode == 'clustered':
+                    if verbose:
+                        print("update_clustered")
+                    self._covdcovmtx.update_clustered(x, block_sizes=block_size, weight=1.0)
+                elif train_mode.startswith('compact_classes'):
+                    if verbose:
+                        print("update_compact_classes:", train_mode)
+                    J = int(train_mode[len('compact_classes'):])
+                    self._covdcovmtx.update_compact_classes(x, block_sizes=block_size, Jdes=J, weight=1.0)
+                elif train_mode == 'serial':
+                    if verbose:
+                        print("update_serial")
+                    self._covdcovmtx.update_serial(x, block_size=block_size)
+                elif train_mode.startswith('DualSerial'):
+                    if verbose:
+                        print("updateDualSerial")
+                    num_blocks = len(x) // block_size
+                    dual_num_blocks = int(train_mode[len("DualSerial"):])
+                    dual_block_size = len(x) // dual_num_blocks
+                    chunk_size = block_size // dual_num_blocks
+                    if verbose:
+                        print("dual_num_blocks = ", dual_num_blocks)
+                    self._covdcovmtx.update_serial(x, block_size=block_size)
+                    x2 = numpy.zeros_like(x)
+                    for i in range(num_blocks):
+                        for j in range(dual_num_blocks):
+                            x2[j * dual_block_size + i * chunk_size:j * dual_block_size + (i + 1) * chunk_size] = \
+                                x[i * block_size + j * chunk_size:i * block_size + (j + 1) * chunk_size]
+                    self._covdcovmtx.update_serial(x2, block_size=dual_block_size, weight=0.0)
+                elif train_mode == 'mixed':
+                    if verbose:
+                        print("update mixed")
+                    bs = block_size
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x[0:bs], weight=2.0,
+                                                                              block_size=block_size)
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x[bs:-bs], weight=1.0,
+                                                                              block_size=block_size)
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x[-bs:], weight=2.0,
+                                                                              block_size=block_size)
+                    self._covdcovmtx.update_serial(x, block_size=block_size)
+                elif train_mode[0:6] == 'window':
+                    window_halfwidth = int(train_mode[6:])
+                    if verbose:
+                        print("Window (%d)" % window_halfwidth)
+                    self._covdcovmtx.update_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                elif train_mode[0:7] == 'fwindow':
+                    window_halfwidth = int(train_mode[7:])
+                    if verbose:
+                        print("Fast Window (%d)" % window_halfwidth)
+                    self._covdcovmtx.update_fast_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                elif train_mode[0:13] == 'mirror_window':
+                    window_halfwidth = int(train_mode[13:])
+                    if verbose:
+                        print("Mirroring Window (%d)" % window_halfwidth)
+                    self._covdcovmtx.update_mirroring_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                elif train_mode[0:14] == 'smirror_window':
+                    window_halfwidth = int(train_mode[14:])
+                    if verbose:
+                        print("Slow Mirroring Window (%d)" % window_halfwidth)
+                    self._covdcovmtx.update_slow_mirroring_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                elif train_mode == 'graph':
+                    if verbose:
+                        print("update_graph")
+                    self._covdcovmtx.update_graph(x, node_weights=node_weights, edge_weights=edge_weights, weight=1.0)
+                elif train_mode == 'graph_old':
+                    if verbose:
+                        print("update_graph_old")
+                    self._covdcovmtx.update_graph_old(x, node_weights=node_weights, edge_weights=edge_weights, weight=1.0)
+                elif train_mode == 'smart_unlabeled2':
+                    if verbose:
+                        print("smart_unlabeled2")
+                    N2 = x.shape[0]
+
+                    N1 = Q1 = self._covdcovmtx.num_samples * 1.0
+                    R1 = self._covdcovmtx.num_diffs * 1.0
+                    sum_x_labeled_2D = self._covdcovmtx.sum_x.reshape((1, -1)) + 0.0
+                    sum_prod_x_labeled = self._covdcovmtx.sum_prod_x + 0.0
+                    if verbose:
+                        print("Original sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+
+                    weight_fraction_unlabeled = 0.2  # 0.1, 0.25
+                    additional_weight_unlabeled = -0.025  # 0.02 0.25, 0.65?
+
+                    w1 = Q1 * 1.0 / R1 * (1.0 - weight_fraction_unlabeled)
+                    if verbose:
+                        print("weight_fraction_unlabeled=", weight_fraction_unlabeled)
+                        print("N1=Q1=", Q1, "R1=", R1, "w1=", w1)
+                        print("")
+
+                    self._covdcovmtx.sum_prod_diffs *= w1
+                    self._covdcovmtx.num_diffs *= w1
+                    if verbose:
+                        print("After diff scaling: num_samples=", self._covdcovmtx.num_samples)
+                        print("num_diffs=", self._covdcovmtx.num_diffs, "\n")
+
+                    node_weights2 = Q1 * weight_fraction_unlabeled / N2  # w2*N1
+                    w12 = node_weights2 / N1  # One directional weights
+                    if verbose:
+                        print("w12 (one dir)", w12)
+
+                    sum_x_unlabeled_2D = x.sum(axis=0).reshape((1, -1))
+                    sum_prod_x_unlabeled = mdp.utils.mult(x.T, x)
+
+                    self._covdcovmtx.add_samples(sum_prod_x_unlabeled, sum_x_unlabeled_2D.flatten(), num_samples=N2,
+                                                weight=node_weights2)
+                    if verbose:
+                        print("After adding unlabeled nodes: num_samples=", self._covdcovmtx.num_samples)
+                        print("num_diffs=", self._covdcovmtx.num_diffs)
+                        print("sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+                        print("")
+
+                        print("N2=", N2, "node_weights2=", node_weights2)
+
+                    additional_diffs = sum_prod_x_unlabeled * N1 - \
+                                       mdp.utils.mult(sum_x_labeled_2D.T, sum_x_unlabeled_2D) - \
+                                       mdp.utils.mult(sum_x_unlabeled_2D.T, sum_x_labeled_2D) + sum_prod_x_labeled * N2
+                    if verbose:
+                        print("w12=", w12, "additional_diffs=", additional_diffs)
+                    self._covdcovmtx.add_diffs(2 * additional_diffs, 2 * N1 * N2,
+                                              weight=w12)  # to account for both directions
+                    if verbose:
+                        print("After mixed diff addition: num_samples=", self._covdcovmtx.num_samples)
+                        print("num_diffs=", self._covdcovmtx.num_diffs)
+                        print("sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+
+                        print("\n Adding complete graph for unlabeled data")
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x, weight=additional_weight_unlabeled,
+                                                                              block_size=N2)
+                    if verbose:
+                        print("After complete x2 addition: num_samples=", self._covdcovmtx.num_samples)
+                        print("num_diffs=", self._covdcovmtx.num_diffs)
+                        print("sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+
+                elif train_mode == 'smart_unlabeled3':
+                    if verbose:
+                        print("smart_unlabeled3")
+                    N2 = x.shape[0]
+
+                    N1 = Q1 = self._covdcovmtx.num_samples * 1.0
+                    R1 = self._covdcovmtx.num_diffs * 1.0
+                    if verbose:
+                        print("N1=Q1=", Q1, "R1=", R1, "N2=", N2)
+
+                    v = 2.0 ** (-9.5)  # 500.0/4500 #weight of unlabeled samples (making it "500" vs "500")
+                    C = 10.0  # 10.0 #Clustered graph assumed, with C classes, and each one having N1/C samples
+                    if verbose:
+                        print("v=", v, "C=", C)
+
+                    v_norm = v / C
+                    N1_norm = N1 / C
+
+                    sum_x_labeled = self._covdcovmtx.sum_x.reshape((1, -1)) + 0.0
+                    sum_prod_x_labeled = self._covdcovmtx.sum_prod_x + 0.0
+
+                    if verbose:
+                        print("Original (Diag(C')/num_diffs.avg)**0.5 =", ((numpy.diagonal(
+                            self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+
+                    weight_adjustment = (N1_norm - 1) / (N1_norm - 1 + v_norm * N2)
+                    if verbose:
+                        print("weight_adjustment =", weight_adjustment, "w11=", 1 / (N1_norm - 1 + v_norm * N2))
+                    # w1 = Q1*1.0/R1 * (1.0-weight_fraction_unlabeled)
+
+                    self._covdcovmtx.sum_x *= weight_adjustment
+                    self._covdcovmtx.sum_prod_x *= weight_adjustment
+                    self._covdcovmtx.num_samples *= weight_adjustment
+                    self._covdcovmtx.sum_prod_diffs *= weight_adjustment
+                    self._covdcovmtx.num_diffs *= weight_adjustment
+                    node_weights_complete_1 = weight_adjustment
+                    if verbose:
+                        print("num_diffs (w11) after weight_adjustment=", self._covdcovmtx.num_diffs)
+                    w11 = 1 / (N1_norm - 1 + v_norm * N2)
+                    if verbose:
+                        print("After adjustment (Diag(C')/num_diffs.avg)**0.5 =", ((numpy.diagonal(
+                        self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+                        print("")
+
+                    # ##Connections within unlabeled data (notice that C times this is equivalent to
+                    # v*v/(N1+v*(N2-1)) once)
+                    w22 = 0.5 * 2 * v_norm * v_norm / (N1_norm + v_norm * (N2 - 1))
+                    sum_x_unlabeled = x.sum(axis=0).reshape((1, -1))
+                    sum_prod_x_unlabeled = mdp.utils.mult(x.T, x)
+                    node_weights_complete_2 = w22 * (N2 - 1) * C
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x, weight=node_weights_complete_2,
+                                                                              block_size=N2)
+                    if verbose:
+                        print("w22=", w22, "node_weights_complete_2*N2=", node_weights_complete_2 * N2)
+                        print("After adding complete 2: num_samples=", self._covdcovmtx.num_samples)
+                        print("num_diffs=", self._covdcovmtx.num_diffs)
+                        print(" (Diag(C')/num_diffs.avg)**0.5 =", ((numpy.diagonal(
+                            self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+                        print("")
+
+                    # Connections between labeled and unlabeled samples
+                    w12 = 2 * 0.5 * v_norm * (1 / (N1_norm - 1 + v_norm * N2) + 1 / (
+                        N1_norm + v_norm * (N2 - 1)))  # Accounts for transitions in both directions
+                    if verbose:
+                        print("(twice) w12=", w12)
+                    sum_prod_diffs_mixed = w12 * (N1 * sum_prod_x_unlabeled -
+                                                  (mdp.utils.mult(sum_x_labeled.T, sum_x_unlabeled) +
+                                                   mdp.utils.mult(sum_x_unlabeled.T, sum_x_labeled)) +
+                                                  N2 * sum_prod_x_labeled)
+                    self._covdcovmtx.sum_prod_diffs += sum_prod_diffs_mixed
+                    self._covdcovmtx.num_diffs += C * N1_norm * N2 * w12  # w12 already counts twice
+                    if verbose:
+                        print(" (Diag(mixed)/num_diffs.avg)**0.5 =", ((numpy.diagonal(sum_prod_diffs_mixed) /
+                                                                   (C * N1_norm * N2 * w12)).mean()) ** 0.5, "\n")
+
+                    # Additional adjustment for node weights of unlabeled data
+                    missing_weight_unlabeled = v - node_weights_complete_2
+                    missing_weight_labeled = 1.0 - node_weights_complete_1
+                    if verbose:
+                        print("missing_weight_unlabeled=", missing_weight_unlabeled)
+                        print("Before two final add_samples: num_samples=", self._covdcovmtx.num_samples)
+                        print("num_diffs=", self._covdcovmtx.num_diffs)
+                    self._covdcovmtx.add_samples(sum_prod_x_unlabeled, sum_x_unlabeled, N2, missing_weight_unlabeled)
+                    self._covdcovmtx.add_samples(sum_prod_x_labeled, sum_x_labeled, N1, missing_weight_labeled)
+                    if verbose:
+                        print("Final transformation: num_samples=", self._covdcovmtx.num_samples)
+                        print("num_diffs=", self._covdcovmtx.num_diffs)
+                        print("Summary v11=%f+%f, v22=%f+%f" % (weight_adjustment, missing_weight_labeled,
+                                                            node_weights_complete_2, missing_weight_unlabeled))
+                        print("Summary w11=%f, w22=%f, w12(two ways)=%f" % (w11, w22, w12))
+                        print("Summary (N1/C-1)*w11=%f, N2*w12 (one way)=%f" % ((N1 / C - 1) * w11, N2 * w12 / 2))
+                        print("Summary (N2-1)*w22*C=%f, N1*w12 (one way)=%f" % ((N2 - 1) * w22 * C, N1 * w12 / 2))
+                        print("Summary (Diag(C')/num_diffs.avg)**0.5 =", ((numpy.diagonal(
+                            self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+                elif train_mode == 'ignore_data':
+                    if verbose:
+                        print("Training graph: ignoring data")
+                else:
+                    ex = "Unknown training method"
+                    raise Exception(ex)
+
+    def _inverse(self, y):
+        """ This function uses a pseudoinverse of the matrix sf to approximate an inverse to the transformation.
+        """
+        if self.pinv is None:
+            self.pinv = pinv(self.sf)
+        return mult(y, self.pinv) + self.avg
+
+    def _stop_training(self, debug=False, verbose=None):
+        if verbose is None:
+           verbose = self.verbose
+        if verbose:
+            print("stop_training: self.block_size=", self.block_size)
+            print("self._covdcovmtx.num_samples = ", self._covdcovmtx.num_samples)
+            print("self._covdcovmtx.num_diffs= ", self._covdcovmtx.num_diffs)
+        self.cov_mtx, self.avg, self.dcov_mtx = self._covdcovmtx.fix()
+
+        if verbose:
+            print("Finishing GSFA training: ", self._covdcovmtx.num_samples)
+            print(" num_samples, and ", self._covdcovmtx.num_diffs, " num_diffs")
+            print("DCov[0:3,0:3] is", self.dcov_mtx[0:3, 0:3])
+
+        rng = self._set_range()
+
+        # Solve the generalized eigenvalue problem
+        # the eigenvalues are already ordered in ascending order
+        try:
+            if verbose:
+                print("***Range used=", rng)
+            self.d, self.sf = self._symeig(self.dcov_mtx, self.cov_mtx, range=rng, overwrite=(not debug))
+            d = self.d
+            # check that we get only non-negative eigenvalues
+            if d.min() < 0:
+                raise SymeigException("Got negative eigenvalues: %s." % str(d))
+        except SymeigException as exception:
+            ex = str(exception) + "\n Covariance matrices may be singular."
+            raise Exception(ex)
+
+        del self._covdcovmtx
+        del self.cov_mtx
+        del self.dcov_mtx
+        self.cov_mtx = self.dcov_mtx = self._covdcovmtx = None
+        self._bias = mult(self.avg, self.sf)
+        if verbose:
+            print("shape of GSFANode.sf is=", self.sf.shape)
+
+    def _set_range(self):
+        if self.output_dim is not None and self.output_dim <= self.input_dim:
+            # (eigenvalues sorted in ascending order)
+            rng = (1, self.output_dim)
+        else:
+            # otherwise, keep all output components
+            rng = None
+            self.output_dim = self.input_dim
+        return rng
+
+##############################################################################################################
+#                              HELPER FUNCTIONS                                                              #
+##############################################################################################################
+
+def graph_delta_values(y, edge_weights):
+    """ Computes delta values from an arbitrary graph as in the objective 
+    function of GSFA. The feature vectors are not normalized to weighted 
+    unit variance or weighted zero mean.
+    """
+    R = 0
+    deltas = 0
+    for (i, j) in edge_weights.keys():
+        w_ij = edge_weights[(i, j)]
+        deltas += w_ij * (y[j] - y[i]) ** 2
+        R += w_ij
+    return deltas / R
+
+
+def comp_delta(x):
+    """ Computes delta values as in the objective function of SFA.
+    The feature vectors are not normalized to unit variance or zero mean.
+    """
+    xderiv = x[1:, :] - x[:-1, :]
+    return (xderiv ** 2).mean(axis=0)
+
+
+def Hamming_weight(integer_list):
+    """ Computes the Hamming weight of an integer or a list of integers (number of bits equal to one) 
+    """
+    if isinstance(integer_list, list):
+        return [Hamming_weight(k) for k in integer_list]
+    elif isinstance(integer_list, int):
+        w = 0
+        n = integer_list
+        while n > 0:
+            if n % 2:
+                w += 1
+            n = n // 2
+        return w
+    else:
+        er = "unsupported input type for Hamming_weight:" + str(integer_list)
+        raise Exception(er)
+
+
+class CovDCovMatrix(object):
+    """Special purpose class to compute the covariance/second moment matrices used by GSFA.
+       It supports efficiently training methods for various graphs: e.g., clustered, serial, mixed.
+       Joint computation of these matrices is typically more efficient than their separate computation.
+    """
+    def __init__(self, verbose=False):
+        """Variable descriptions:
+            sum_x: a vector with the sum of all data samples
+            sum_prod_x: a matrix with sum of all samples multiplied by their transposes
+            num_samples: the total weighted number of samples
+            sum_prod_diffs: a matrix with sum of all sample differences multiplied by their transposes
+            num_diffs: the total weighted number of sample differences
+            verbose: a Boolean verbosity parameter
+
+        The following variables are available after fix() has been called.
+            cov_mtx: the resulting covariance matrix of the samples
+            avg: the average sample
+            dcov_mtx: the resulting second-moment matrix of the sample differences
+        """
+        self.sum_x = None
+        self.sum_prod_x = None
+        self.num_samples = 0
+        self.sum_prod_diffs = None
+        self.num_diffs = 0
+        self.verbose = verbose
+
+        # Variables used to store the final matrices
+        self.cov_mtx = None
+        self.avg = None
+        self.dcov_mtx = None
+
+    def add_samples(self, sum_prod_x, sum_x, num_samples, weight=1.0):
+        """ The given sample information (sum_prod_x, sum_x, num_samples) is added to the cumulative
+        computation of the covariance matrix.
+        """
+        weighted_sum_x = sum_x * weight
+        weighted_sum_prod_x = sum_prod_x * weight
+        weighted_num_samples = num_samples * weight
+
+        if self.sum_prod_x is None:
+            self.sum_prod_x = weighted_sum_prod_x
+            self.sum_x = weighted_sum_x
+        else:
+            self.sum_prod_x = self.sum_prod_x + weighted_sum_prod_x
+            self.sum_x = self.sum_x + weighted_sum_x
+
+        self.num_samples = self.num_samples + weighted_num_samples
+
+    def add_diffs(self, sum_prod_diffs, num_diffs, weight=1.0):
+        """ The given sample differences information (sum_prod_diffs, num_diffs) is added to the cumulative
+        computation of the second-moment differences matrix.
+        """
+        weighted_sum_prod_diffs = sum_prod_diffs * weight
+        weighted_num_diffs = num_diffs * weight
+
+        if self.sum_prod_diffs is None:
+            self.sum_prod_diffs = weighted_sum_prod_diffs
+        else:
+            self.sum_prod_diffs = self.sum_prod_diffs + weighted_sum_prod_diffs
+
+        self.num_diffs = self.num_diffs + weighted_num_diffs
+
+    def update_unlabeled(self, x, weight=1.0):
+        """ Add unlabeled samples to the covariance matrix (DCov remains unmodified) """
+        num_samples, dim = x.shape
+
+        sum_x = x.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x.T, x)
+        self.add_samples(sum_prod_x, sum_x, num_samples, weight)
+
+    def update_regular(self, x, weight=1.0):
+        """This is equivalent to regular SFA training (except for the final feature scale). """
+        num_samples, dim = x.shape
+
+        # Update Cov Matrix
+        sum_x = x.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x.T, x)
+        self.add_samples(sum_prod_x, sum_x, num_samples, weight)
+
+        # Update DCov Matrix
+        diffs = x[1:, :] - x[:-1, :]
+        num_diffs = num_samples - 1
+        sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
+        self.add_diffs(sum_prod_diffs, num_diffs, weight)
+
+    def update_graph(self, x, node_weights=None, edge_weights=None, weight=1.0):
+        """Updates the covariance/second moment matrices using an user-provided graph specified by
+        (x, node weights, edge weights, and a global weight).
+
+         Usually sum(node_weights) = num_samples.
+         """
+        num_samples, dim = x.shape
+
+        if node_weights is None:
+            node_weights = numpy.ones(num_samples)
+
+        if len(node_weights) != num_samples:
+            er = "Node weights should be the same length %d as the number of samples %d" % \
+                 (len(node_weights), num_samples)
+            raise Exception(er)
+
+        if edge_weights is None:
+            er = "edge_weights should be a dictionary with entries: d[(i,j)] = w_{i,j} or an NxN array"
+            raise Exception(er)
+
+        if isinstance(edge_weights, numpy.ndarray):
+            # TODO: eventually make sure edge_weights are symmetric
+            # TODO: eventually make sure consistency restriction is fulfilled
+            if edge_weights.shape != (num_samples, num_samples):
+                er = "Error, dimensions of edge_weights should be (%d,%d) but is (%d,%d)" % \
+                     (num_samples, num_samples, edge_weights.shape[0], edge_weights.shape[1])
+                raise Exception(er)
+
+        node_weights_column = node_weights.reshape((num_samples, 1))
+        # Update Cov Matrix
+        weighted_x = x * node_weights_column
+
+        weighted_sum_x = weighted_x.sum(axis=0)
+        weighted_sum_prod_x = mdp.utils.mult(x.T, weighted_x)
+        weighted_num_samples = node_weights.sum()
+        self.add_samples(weighted_sum_prod_x, weighted_sum_x, weighted_num_samples, weight=weight)
+
+        # Update DCov Matrix
+        if isinstance(edge_weights, numpy.ndarray):
+            weighted_num_diffs = edge_weights.sum()  # normalization constant R
+            prod1 = weighted_sum_prod_x  # TODO: eventually check these equations, they might only work if Q==R
+            prod2 = mdp.utils.mult(mdp.utils.mult(x.T, edge_weights), x)
+            weighted_sum_prod_diffs = 2 * prod1 - 2 * prod2
+            self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs, weight=weight)
+        else:
+            num_diffs = len(edge_weights)
+            diffs = numpy.zeros((num_diffs, dim))
+            weighted_diffs = numpy.zeros((num_diffs, dim))
+            weighted_num_diffs = 0
+            for ii, (i, j) in enumerate(edge_weights.keys()):
+                diff = x[j, :] - x[i, :]
+                diffs[ii] = diff
+                w_ij = edge_weights[(i, j)]
+                weighted_diff = diff * w_ij
+                weighted_diffs[ii] = weighted_diff
+                weighted_num_diffs += w_ij
+
+            weighted_sum_prod_diffs = mdp.utils.mult(diffs.T, weighted_diffs)
+            self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs, weight=weight)
+
+    def update_graph_old(self, x, node_weights=None, edge_weights=None, weight=1.0):
+        """This method performs the same task as update_graph. It is slower than update_graph because it
+        has not been optimized. Thus, it is mainly useful to verify the correctness of update_graph.
+        """
+        num_samples, dim = x.shape
+
+        if node_weights is None:
+            node_weights = numpy.ones(num_samples)
+
+        if len(node_weights) != num_samples:
+            er = "Node weights should be the same length %d as the number of samples %d" % \
+                 (len(node_weights), num_samples)
+            raise Exception(er)
+
+        if edge_weights is None:
+            er = "edge_weights should be a dictionary with entries: d[(i,j)] = w_{i,j} or an NxN array"
+            raise Exception(er)
+
+        if isinstance(edge_weights, numpy.ndarray):
+            if edge_weights.shape == (num_samples, num_samples):
+                e_w = {}
+                for i in range(num_samples):
+                    for j in range(num_samples):
+                        if edge_weights[i, j] != 0:
+                            e_w[(i, j)] = edge_weights[i, j]
+                edge_weights = e_w
+            else:
+                er = "Error, dimensions of edge_weights should be (%d,%d) but is (%d,%d)" % \
+                     (num_samples, num_samples, edge_weights.shape[0], edge_weights.shape[1])
+                raise Exception(er)
+        node_weights_column = node_weights.reshape((num_samples, 1))
+        # Update Cov Matrix
+        weighted_x = x * node_weights_column
+
+        weighted_sum_x = weighted_x.sum(axis=0)
+        weighted_sum_prod_x = mdp.utils.mult(x.T, weighted_x)
+        weighted_num_samples = node_weights.sum()
+        self.add_samples(weighted_sum_prod_x, weighted_sum_x, weighted_num_samples, weight=weight)
+
+        # Update DCov Matrix
+        num_diffs = len(edge_weights)
+        diffs = numpy.zeros((num_diffs, dim))
+        weighted_diffs = numpy.zeros((num_diffs, dim))
+        weighted_num_diffs = 0
+        for ii, (i, j) in enumerate(edge_weights.keys()):
+            diff = x[j, :] - x[i, :]
+            diffs[ii] = diff
+            w_ij = edge_weights[(i, j)]
+            weighted_diff = diff * w_ij
+            weighted_diffs[ii] = weighted_diff
+            weighted_num_diffs += w_ij
+
+        weighted_sum_prod_diffs = mdp.utils.mult(diffs.T, weighted_diffs)
+        self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs, weight=weight)
+
+    def update_mirroring_sliding_window(self, x, weight=1.0, window_halfwidth=2):
+        """ Note: this method makes sense according to the consistency restriction for "larger" windows. """
+        num_samples, dim = x.shape
+        width = window_halfwidth  # window_halfwidth is too long to write it complete each time
+        if 2 * width >= num_samples:
+            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            raise Exception(ex)
+
+        # Update Cov Matrix. All samples have same weight
+        sum_x = x.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x.T, x)
+        self.add_samples(sum_prod_x, sum_x, num_samples, weight)
+
+        # Update DCov Matrix. First mirror the borders
+        x_mirror = numpy.zeros((num_samples + 2 * width, dim))
+        x_mirror[width:-width] = x  # center part
+        x_mirror[0:width, :] = x[0:width, :][::-1, :]  # first end
+        x_mirror[-width:, :] = x[-width:, :][::-1, :]  # second end
+
+        # Center part
+        x_full = x
+        sum_prod_x_full = mdp.utils.mult(x_full.T, x_full)
+
+        Aacc123 = numpy.zeros((dim, dim))
+        for i in range(0, 2 * width):  # [0, 2*width-1]
+            Aacc123 += (i + 1) * mdp.utils.mult(x_mirror[i:i + 1, :].T, x_mirror[i:i + 1, :])  # (i+1)=1,2,3..., 2*width
+
+        for i in range(num_samples, num_samples + 2 * width):  # [num_samples-width, num_samples-1]
+            Aacc123 += (num_samples + 2 * width - i) * mdp.utils.mult(x_mirror[i:i + 1, :].T, x_mirror[i:i + 1, :])
+        x_middle = x_mirror[2 * width:-2 * width, :]  # intermediate values of x, which are connected 2*width+1 times
+        Aacc123 += (2 * width + 1) * mdp.utils.mult(x_middle.T, x_middle)
+
+        b = numpy.zeros((num_samples + 1 + 2 * width, dim))
+        b[1:] = x_mirror.cumsum(axis=0)
+        B = b[2 * width + 1:] - b[0:-2 * width - 1]
+        Bprod = mdp.utils.mult(x_full.T, B)
+
+        sum_prod_diffs_full = (2 * width + 1) * sum_prod_x_full + Aacc123 - Bprod - Bprod.T
+        num_diffs = num_samples * (2 * width)  # removed zero differences
+        self.add_diffs(sum_prod_diffs_full, num_diffs, weight)
+
+
+    def update_slow_mirroring_sliding_window(self, x, weight=1.0, window_halfwidth=2):
+        """ This is an unoptimized version of update_mirroring_sliding_window. """
+        num_samples, dim = x.shape
+        width = window_halfwidth  # window_halfwidth is way too long to write it
+        if 2 * width >= num_samples:
+            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            raise Exception(ex)
+
+        # Update Cov Matrix. All samples have same weight
+        sum_x = x.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x.T, x)
+        self.add_samples(sum_prod_x, sum_x, num_samples, weight)
+
+        # Update DCov Matrix. window = numpy.ones(2*width+1) # Rectangular window
+        x_mirror = numpy.zeros((num_samples + 2 * width, dim))
+        x_mirror[width:-width] = x  # center part
+        x_mirror[0:width, :] = x[0:width, :][::-1, :]  # start of the sequence
+        x_mirror[-width:, :] = x[-width:, :][::-1, :]  # end of the sequence
+
+        for offset in range(-width, width + 1):
+            if offset == 0:
+                pass
+            else:
+                diffs = x_mirror[offset + width:offset + width + num_samples, :] - x
+
+                sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
+                num_diffs = len(diffs)
+                self.add_diffs(sum_prod_diffs, num_diffs, weight)
+
+
+    def update_slow_truncating_sliding_window(self, x, weight=1.0, window_halfwidth=2):
+        """ Truncating Window (original slow/reference version). """
+        num_samples, dim = x.shape
+        width = window_halfwidth  # window_halfwidth is way too long to write it
+        if 2 * width >= num_samples:
+            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            raise Exception(ex)
+
+        # Update Cov Matrix. All samples have same weight
+        sum_x = x.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x.T, x)
+        self.add_samples(sum_prod_x, sum_x, num_samples, weight)
+
+        # Update DCov Matrix. window = numpy.ones(2*width+1) # Rectangular window
+        x_extended = numpy.zeros((num_samples + 2 * width, dim))
+        x_extended[width:-width] = x  # center part is preserved, extreme samples are zero
+
+        # Negative offset is not considered because it is equivalent to the positive one, thereore the factor 2
+        for offset in range(1, width + 1):
+            diffs = x_extended[offset + width:width + num_samples, :] - x[0:-offset, :]
+            sum_prod_diffs = 2 * mdp.utils.mult(diffs.T, diffs)
+            num_diffs = 2 * (num_samples - offset)
+            self.add_diffs(sum_prod_diffs, num_diffs, weight)
+
+    def update_fast_sliding_window(self, x, weight=1.0, window_halfwidth=2):
+        """ Sliding window with node-weight correction. """
+        num_samples, dim = x.shape
+        width = window_halfwidth
+        if 2 * width >= num_samples:
+            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            raise Exception(ex)
+
+        # MOST CORRECT VERSION
+        x_sel = x + 0.0
+        w_up = numpy.arange(width, 2 * width) / (2.0 * width)
+        w_up = w_up.reshape((width, 1))
+        w_down = numpy.arange(2 * width - 1, width - 1, -1) / (2.0 * width)
+        w_down = w_down.reshape((width, 1))
+        x_sel[0:width, :] = x_sel[0:width, :] * w_up
+        x_sel[-width:, :] = x_sel[-width:, :] * w_down
+
+        sum_x = x_sel.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x_sel.T, x)  # There was a bug here, x_sel used twice!!!
+        self.add_samples(sum_prod_x, sum_x, num_samples - (0.5 * window_halfwidth - 0.5), weight)
+
+        # Update DCov Matrix. First we compute the borders
+        # Left border
+        for i in range(0, width):  # [0, width -1]
+            diffs = x[0:width + i + 1, :] - x[i, :]
+            sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
+            num_diffs = len(diffs) - 1  # removed zero differences
+            # print "N1=", num_diffs
+            # print "sum_prod_diffs[0]=", sum_prod_diffs[0]
+            self.add_diffs(sum_prod_diffs, num_diffs, weight)
+        # Right border
+        for i in range(num_samples - width, num_samples):  # [num_samples-width, num_samples-1]
+            diffs = x[i - width:num_samples, :] - x[i, :]
+            sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
+            num_diffs = len(diffs) - 1  # removed zero differences
+            # print "N2=", num_diffs
+            # print "sum_prod_diffs[0]=", sum_prod_diffs[0]
+            self.add_diffs(sum_prod_diffs, num_diffs, weight)
+
+        # Center part
+        x_full = x[width:num_samples - width, :]
+        sum_prod_x_full = mdp.utils.mult(x_full.T, x_full)
+
+        Aacc123 = numpy.zeros((dim, dim))
+        for i in range(0, 2 * width):  # [0, 2*width-1]
+            Aacc123 += (i + 1) * mdp.utils.mult(x[i:i + 1, :].T, x[i:i + 1, :])  # (i+1)=1,2,3..., 2*width
+
+        for i in range(num_samples - 2 * width, num_samples):  # [num_samples-width, num_samples-1]
+            Aacc123 += (num_samples - i) * mdp.utils.mult(x[i:i + 1, :].T,
+                                                          x[i:i + 1, :])  # (num_samples-1)=2*width,...,3,2,1
+
+        # intermediate values of x, which are connected 2*width+1 times
+        x_middle = x[2 * width:num_samples - 2 * width, :]
+
+        Aacc123 += (2 * width + 1) * mdp.utils.mult(x_middle.T, x_middle)
+
+        b = numpy.zeros((num_samples + 1, dim))
+        b[1:] = x.cumsum(axis=0)
+        #        for i in range(1,num_samples+1):
+        #            b[i] = b[i-1] + x[i-1,:]
+        #        A = a[2*width+1:]-a[0:-2*width-1]
+        B = b[2 * width + 1:] - b[0:-2 * width - 1]
+        #        Aacc = A.sum(axis=0)
+        Bprod = mdp.utils.mult(x_full.T, B)
+        sum_prod_diffs_full = (2 * width + 1) * sum_prod_x_full + Aacc123 - Bprod - Bprod.T
+        num_diffs = (num_samples - 2 * width) * (2 * width)  # removed zero differences
+        self.add_diffs(sum_prod_diffs_full, num_diffs, weight)
+
+    def update_sliding_window(self, x, weight=1.0, window_halfwidth=2):
+        num_samples, dim = x.shape
+        width = window_halfwidth
+        if 2 * width >= num_samples:
+            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            raise Exception(ex)
+
+        # MOST CORRECT VERSION
+        x_sel = x + 0.0
+        w_up = numpy.arange(width, 2 * width) / (2.0 * width)
+        w_up = w_up.reshape((width, 1))
+        w_down = numpy.arange(2 * width - 1, width - 1, -1) / (2.0 * width)
+        w_down = w_down.reshape((width, 1))
+        x_sel[0:width, :] = x_sel[0:width, :] * w_up
+        x_sel[-width:, :] = x_sel[-width:, :] * w_down
+
+        sum_x = x_sel.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x_sel.T, x)  # Bug fixed!!! computing w * X^T * X, with X=(x1,..xN)^T
+        self.add_samples(sum_prod_x, sum_x, num_samples - (0.5 * window_halfwidth - 0.5), weight)  # weights verified
+
+        # Update DCov Matrix
+        # window = numpy.ones(2*width+1) # Rectangular window, used always here!
+        # diffs = numpy.zeros((num_samples - 2 * width, dim))
+        # This can be made faster (twice) due to symmetry
+        for offset in range(-width, width + 1):
+            if offset == 0:
+                pass
+            else:
+                if offset > 0:
+                    diffs = x[offset:, :] - x[0:num_samples - offset, :]
+                    sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
+                    num_diffs = len(diffs)
+                    self.add_diffs(sum_prod_diffs, num_diffs, weight)
+
+    # Add samples belonging to a serial training graph
+    def update_serial(self, x, block_size, weight=1.0):
+        num_samples, dim = x.shape
+        if block_size is None:
+            er = "block_size must be specified"
+            raise Exception(er)
+
+        if isinstance(block_size, numpy.ndarray):
+            err = "Inhomogeneous block sizes not yet supported in update_serial"
+            raise Exception(err)
+        elif isinstance(block_size, list):
+            block_size_0 = block_size[0]
+            for bs in block_size:
+                if bs != block_size_0:
+                    er = "for serial graph all groups must have same group size (block_size constant), but " + \
+                         str(bs) + "!=" + str(block_size_0)
+                    raise Exception(er)
+            block_size = block_size_0
+
+        if num_samples % block_size > 0:
+            err = "Consistency error: num_samples is not a multiple of block_size"
+            raise Exception(err)
+        num_blocks = num_samples // block_size
+
+        # warning, plenty of dtype missing!!!!!!!!
+        # Optimize computation of x.T ???
+        # Warning, remove last element of x (incremental computation)!!!
+
+        # Correlation Matrix. Computing sum of outer products (the easy part)
+        xp = x[block_size:num_samples - block_size]
+        x_b_ini = x[0:block_size]
+        x_b_end = x[num_samples - block_size:]
+        sum_x = x_b_ini.sum(axis=0) + 2 * xp.sum(axis=0) + x_b_end.sum(axis=0)
+
+        sum_prod_x = mdp.utils.mult(x_b_ini.T, x_b_ini) + 2 * mdp.utils.mult(xp.T, xp) + mdp.utils.mult(x_b_end.T,
+                                                                                                        x_b_end)
+        num_samples = 2 * block_size + 2 * (num_samples - 2 * block_size)
+
+        self.add_samples(sum_prod_x, sum_x, num_samples, weight)
+
+        # DCorrelation Matrix. Compute medias signal
+        media = numpy.zeros((num_blocks, dim))
+        for i in range(num_blocks):
+            media[i] = x[i * block_size:(i + 1) * block_size].sum(axis=0) * (1.0 / block_size)
+
+        media_a = media[0:-1]
+        media_b = media[1:]
+        sum_prod_mixed_meds = (mdp.utils.mult(media_a.T, media_b) + mdp.utils.mult(media_b.T, media_a))
+        #        prod_first_media = numpy.outer(media[0], media[0]) * block_size
+        #        prod_last_media = numpy.outer(media[num_blocks-1], media[num_blocks-1]) * block_size
+        prod_first_block = mdp.utils.mult(x[0:block_size].T, x[0:block_size])
+        prod_last_block = mdp.utils.mult(x[num_samples - block_size:].T, x[num_samples - block_size:])
+
+        #       WARNING? why did I remove one factor block_size?
+        num_diffs = block_size * (num_blocks - 1)
+
+        sum_prod_diffs = (block_size * sum_prod_x -
+                          (block_size * block_size) * sum_prod_mixed_meds) * (1.0 / block_size)
+        self.add_diffs(2 * sum_prod_diffs, 2 * num_diffs, weight)  # NEW: Factor 2 to account for both directions
+
+    # Weight should refer to node weights
+    def update_clustered(self, x, block_sizes=None, weight=1.0, include_self_loops=True):
+        num_samples, dim = x.shape
+
+        if isinstance(block_sizes, int):
+            return self.update_clustered_homogeneous_block_sizes(x, weight=weight, block_size=block_sizes,
+                                                                 include_self_loops=include_self_loops)
+
+        if block_sizes is None:
+            er = "error, block_size not specified!!!!"
+            raise Exception(er)
+
+        if num_samples != numpy.array(block_sizes).sum():
+            err = "Inconsistency error: num_samples (%d) is not equal to sum of block_sizes:" % num_samples, block_sizes
+            raise Exception(err)
+
+        counter_sample = 0
+        for block_size in block_sizes:
+            normalized_weight = weight
+            self.update_clustered_homogeneous_block_sizes(x[counter_sample:counter_sample + block_size, :],
+                                                          weight=normalized_weight, block_size=block_size,
+                                                          include_self_loops=include_self_loops)
+            counter_sample += block_size
+
+    def update_clustered_homogeneous_block_sizes(self, x, weight=1.0, block_size=None, include_self_loops=True):
+        if self.verbose:
+            print("update_clustered_homogeneous_block_sizes ")
+        if block_size is None:
+            er = "error, block_size not specified!!!!"
+            raise Exception(er)
+
+        if isinstance(block_size, numpy.ndarray):
+            er = "Error: inhomogeneous block sizes not supported by this function"
+            raise Exception(er)
+
+        # Assuming block_size is an integer:
+        num_samples, dim = x.shape
+        if num_samples % block_size > 0:
+            err = "Inconsistency error: num_samples (%d) is not a multiple of block_size (%d)" % \
+                  (num_samples, block_size)
+            raise Exception(err)
+        num_blocks = num_samples // block_size
+
+        # warning, plenty of dtype missing! they are just derived from the data.
+        sum_x = x.sum(axis=0)
+        sum_prod_x = mdp.utils.mult(x.T, x)
+        self.add_samples(sum_prod_x, sum_x, num_samples, weight)
+
+        # DCorrelation Matrix. Compute medias signal
+        media = numpy.zeros((num_blocks, dim))
+        for i in range(num_blocks):
+            media[i] = x[i * block_size:(i + 1) * block_size].sum(axis=0) * (1.0 / block_size)
+
+        sum_prod_meds = mdp.utils.mult(media.T, media)
+        # FIX1: AFTER DT in (0,4) normalization
+        num_diffs = num_blocks * block_size  # ## * (block_size-1+1) / (block_size-1)
+        if self.verbose:
+            print("num_diffs in block:", num_diffs, " num_samples:", num_samples)
+        if include_self_loops:
+            sum_prod_diffs = 2.0 * block_size * (sum_prod_x - block_size * sum_prod_meds) / block_size
+        else:
+            sum_prod_diffs = 2.0 * block_size * (sum_prod_x - block_size * sum_prod_meds) / (block_size - 1)
+
+        self.add_diffs(sum_prod_diffs, num_diffs, weight)
+        if self.verbose:
+            print("(Diag(complete)/num_diffs.avg)**0.5 =", ((numpy.diagonal(sum_prod_diffs) / num_diffs).mean()) ** 0.5)
+
+    def update_compact_classes(self, x, block_sizes=None, Jdes=None, weight=1.0):
+        num_samples, dim = x.shape
+
+        if self.verbose:
+            print("block_sizes=", block_sizes, type(block_sizes))
+        if isinstance(block_sizes, list):
+            block_sizes = numpy.array(block_sizes)
+
+        if isinstance(block_sizes, numpy.ndarray):
+            if len(block_sizes) > 1:
+                if block_sizes.var() > 0:
+                    er = "for compact_classes all groups must have the same number of elements (block_sizes)!!!!"
+                    raise Exception(er)
+                else:
+                    block_size = block_sizes[0]
+            else:
+                block_size = block_sizes[0]
+        elif block_sizes is None:
+            er = "error, block_size not specified!!!!"
+            raise Exception(er)
+        else:
+            block_size = block_sizes
+
+        if num_samples % block_size != 0:
+            err = "Inconsistency error: num_samples (%d) must be a multiple of block_size: " % num_samples, block_sizes
+            raise Exception(err)
+
+        num_classes = num_samples // block_size
+        J = int(numpy.log2(num_classes))
+        if Jdes is None:
+            Jdes = J
+        extra_label = Jdes - J  # 0, 1, 2
+
+        if self.verbose:
+            print("Besides J=%d labels, also adding %d labels" % (J, extra_label))
+
+        if num_classes != 2 ** J:
+            err = "Inconsistency error: num_clases %d does not appear to be a power of 2" % num_classes
+            raise Exception(err)
+
+        N = num_samples
+        labels = numpy.zeros((N, J + extra_label))
+        for j in range(J):
+            labels[:, j] = (numpy.arange(N) // block_size // (2 ** (J - j - 1)) % 2) * 2 - 1
+        eigenvalues = numpy.concatenate(([1.0] * (J - 1), numpy.arange(1.0, 0.0, -1.0 / (extra_label + 1))))
+
+        n_taken = [2 ** k for k in range(J)]
+        n_free = list(set(range(num_classes)) - set(n_taken))
+        n_free_weights = Hamming_weight(n_free)
+        order = numpy.argsort(n_free_weights)[::-1]
+
+        for j in range(extra_label):
+            digit = n_free[order[j]]
+            label = numpy.ones(N)
+            for c in range(J):
+                if (digit >> c) % 2:
+                    label *= labels[:, c]
+            if n_free_weights[order[j]] % 2 == 0:
+                label *= -1
+            labels[:, J + j] = label
+
+        eigenvalues = numpy.array(eigenvalues)
+
+        eigenvalues /= eigenvalues.sum()
+        if self.verbose:
+            print("Eigenvalues:", eigenvalues)
+            print("Eigenvalues normalized:", eigenvalues)
+            for j in range(J + extra_label):
+                print("labels[%d]=" % j, labels[:, j])
+
+        for j in range(J + extra_label):
+            set10 = x[labels[:, j] == -1]
+            self.update_clustered_homogeneous_block_sizes(set10, weight=eigenvalues[j],
+                                                          block_size=N // 2)  # first cluster
+            set10 = x[labels[:, j] == 1]
+            self.update_clustered_homogeneous_block_sizes(set10, weight=eigenvalues[j],
+                                                          block_size=N // 2)  # second cluster
+
+    def add_cov_dcov_matrix(self, cov_dcov_mat, adding_weight=1.0, own_weight=1.0):
+        if self.sum_prod_x is None:
+            self.sum_prod_x = cov_dcov_mat.sum_prod_x * adding_weight
+            self.sum_x = cov_dcov_mat.sum_x * adding_weight
+        else:
+            self.sum_prod_x = self.sum_prod_x * own_weight + cov_dcov_mat.sum_prod_x * adding_weight
+            self.sum_x = self.sum_x * own_weight + cov_dcov_mat.sum_x * adding_weight
+        self.num_samples = self.num_samples * own_weight + cov_dcov_mat.num_samples * adding_weight
+        if self.sum_prod_diffs is None:
+            self.sum_prod_diffs = cov_dcov_mat.sum_prod_diffs * adding_weight
+        else:
+            self.sum_prod_diffs = self.sum_prod_diffs * own_weight + cov_dcov_mat.sum_prod_diffs * adding_weight
+        self.num_diffs = self.num_diffs * own_weight + cov_dcov_mat.num_diffs * adding_weight
+
+    def fix(self, divide_by_num_samples_or_differences=True, center_dcov=False):  # include_tail=False,
+        if self.verbose:
+            print("Fixing CovDCovMatrix")
+
+        avg_x = self.sum_x * (1.0 / self.num_samples)
+
+        # THEORY: This computation has a bias
+        # exp_prod_x = self.sum_prod_x * (1.0 / self.num_samples)
+        # prod_avg_x = numpy.outer(avg_x, avg_x)
+        # cov_x = exp_prod_x - prod_avg_x
+        prod_avg_x = numpy.outer(avg_x, avg_x)
+        if divide_by_num_samples_or_differences:  # as specified by the theory on training graphs
+            cov_x = (self.sum_prod_x - self.num_samples * prod_avg_x) / (1.0 * self.num_samples)
+        else:  # standard unbiased estimation used by standard SFA
+            cov_x = (self.sum_prod_x - self.num_samples * prod_avg_x) / (self.num_samples - 1.0)
+
+        # Finalize covariance matrix of dx
+        if divide_by_num_samples_or_differences or True:
+            cov_dx = self.sum_prod_diffs / (1.0 * self.num_diffs)
+        else:
+            cov_dx = self.sum_prod_diffs / (self.num_diffs - 1.0)
+
+        self.cov_mtx = cov_x
+        self.avg = avg_x
+        self.dcov_mtx = cov_dx
+
+        if self.verbose:
+            print("Finishing training CovDcovMtx:", self.num_samples, "num_samples, and", self.num_diffs, "num_diffs")
+            print("Avg[0:3] is", self.avg[0:4])
+            print("Prod_avg_x[0:3,0:3] is", prod_avg_x[0:3,0:3])
+            print("Cov[0:3,0:3] is", self.cov_mtx[0:3,0:3])
+            print("DCov[0:3,0:3] is", self.dcov_mtx[0:3,0:3])
+            print("AvgDiff[0:4] is", avg_diff[0:4])
+            print("Prod_avg_diff[0:3,0:3] is", prod_avg_diff[0:3,0:3])
+            print("Sum_prod_diffs[0:3,0:3] is", self.sum_prod_diffs[0:3,0:3])
+            print("exp_prod_diffs[0:3,0:3] is", exp_prod_diffs[0:3,0:3])
+        return self.cov_mtx, self.avg, self.dcov_mtx
+
+
+# ####### Helper functions for parallel processing and CovDcovMatrices #########
+
+# This function is used by patch_mdp
+# def compute_cov_matrix(x, verbose=False):
+#     print("PCov")
+#     if verbose:
+#         print("Computation Began!!! **********************************************************")
+#         sys.stdout.flush()
+#     covmtx = CovarianceMatrix(bias=True)
+#     covmtx.update(x)
+#     if verbose:
+#         print("Computation Ended!!! **********************************************************")
+#         sys.stdout.flush()
+#     return covmtx
+#
+#
+# def compute_cov_dcov_matrix_clustered(params, verbose=False):
+#     print("PComp")
+#     if verbose:
+#         print("Computation Began!!! **********************************************************")
+#         sys.stdout.flush()
+#     x, block_size, weight = params
+#     covdcovmtx = CovDCovMatrix()
+#     covdcovmtx.update_clustered_homogeneous_block_sizes(x, block_size=block_size, weight=weight)
+#     if verbose:
+#         print("Computation Ended!!! **********************************************************")
+#         sys.stdout.flush()
+#     return covdcovmtx
+#
+#
+# def compute_cov_dcov_matrix_serial(params, verbose=False):
+#     print("PSeq")
+#     if verbose:
+#         print("Computation Began!!! **********************************************************")
+#         sys.stdout.flush()
+#     x, block_size = params
+#     covdcovmtx = CovDCovMatrix()
+#     covdcovmtx.update_serial(x, block_size=block_size)
+#     if verbose:
+#         print("Computation Ended!!! **********************************************************")
+#         sys.stdout.flush()
+#     return covdcovmtx
+#
+#
+# def compute_cov_dcov_matrix_mixed(params, verbose=False):
+#     print("PMixed")
+#     if verbose:
+#         print("Computation Began!!! **********************************************************")
+#         sys.stdout.flush()
+#     x, block_size = params
+#     bs = block_size
+#     covdcovmtx = CovDCovMatrix()
+#     covdcovmtx.update_clustered_homogeneous_block_sizes(x[0:bs], block_size=block_size, weight=0.5)
+#     covdcovmtx.update_clustered_homogeneous_block_sizes(x[bs:-bs], block_size=block_size, weight=1.0)
+#     covdcovmtx.update_clustered_homogeneous_block_sizes(x[-bs:], block_size=block_size, weight=0.5)
+#     covdcovmtx.update_serial(x, block_size=block_size)
+#     if verbose:
+#         print("Computation Ended!!! **********************************************************")
+#         sys.stdout.flush()
+#     return covdcovmtx
+
+
+class iGSFANode(mdp.Node):
+    """This node implements "information-preserving graph-based SFA (iGSFA)", which is the main component of
+    hierarchical iGSFA (HiGSFA).
+
+    For further information, see: Escalante-B., A.-N. and Wiskott, L., "Improved graph-based {SFA}: Information
+    preservation complements the slowness principle", e-print arXiv:1601.03945, http://arxiv.org/abs/1601.03945, 2017
+    """
+
+    def __init__(self, input_dim=None, output_dim=None, pre_expansion_node_class=None, pre_expansion_out_dim=None,
+                 expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
+                 max_length_slow_part=None, slow_feature_scaling_method="sensitivity_based", delta_threshold=1.9999,
+                 reconstruct_with_sfa=True, verbose=False, **argv):
+        """Initializes the iGSFA node.
+
+        pre_expansion_node_class: a node class. An instance of this class is used to filter the data before the
+                                  expansion.
+        pre_expansion_out_dim: the output dimensionality of the above-mentioned node.
+        expansion_funcs: a list of expansion functions to be applied before GSFA.
+        expansion_output_dim: this parameter is used to specify an output dimensionality for some expansion functions.
+        expansion_starting_point: this parameter is also used by some specific expansion functions.
+        max_length_slow_part: fixes an upper bound to the size of the slow part, which is convenient for
+                              computational reasons.
+        slow_feature_scaling_method: the method used to scale the slow features. Valid entries are: None,
+                         "sensitivity_based" (default), "data_dependent", and "QR_decomposition".
+        delta_threshold: this parameter has two different meanings depending on its type. If it is real valued (e.g.,
+                         1.99), it determines the parameter \Delta_threshold, which is used to decide how many slow
+                         features are preserved, depending on their delta values. If it is integer (e.g., 20), it
+                         directly specifies the exact size of the slow part.
+        reconstruct_with_sfa: this Boolean parameter indicates whether the slow part is removed from the input before
+                              PCA is applied.
+
+        More information about parameters 'expansion_funcs' and 'expansion_starting_point' can be found in the
+            documentation of GeneralExpansionNode.
+
+        Note: Training is finished after a single call to the train method, unless multi-train is enabled, which
+              is done by using reconstruct_with_sfa=False and slow_feature_scaling_method in [None, "data_dependent"]. This
+              is necessary to support weight sharing in iGSFA layers (convolutional iGSFA layers).
+        """
+        super(iGSFANode, self).__init__(input_dim=input_dim, output_dim=output_dim, **argv)
+        self.pre_expansion_node_class = pre_expansion_node_class  # Type of node used to expand the data
+        self.pre_expansion_node = None  # Node that expands the input data
+        self.pre_expansion_output_dim = pre_expansion_out_dim
+        self.expansion_output_dim = expansion_output_dim  # Expanded dimensionality
+        self.expansion_starting_point = expansion_starting_point  # Initial parameters for the expansion function
+
+        # creates an expansion node
+        if expansion_funcs:
+            self.exp_node = GeneralExpansionNode(funcs=expansion_funcs, output_dim=self.expansion_output_dim,
+                                                 starting_point=self.expansion_starting_point)
+        else:
+            self.exp_node = None
+
+        self.sfa_node = None
+        self.pca_node = None
+        self.lr_node = None
+        self.max_length_slow_part = max_length_slow_part  # upper limit to the size of the slow part
+
+        # Parameter that defines the size of the slow part. Its meaning depnds on wheather it is an integer or a float
+        self.delta_threshold = delta_threshold
+        # Indicates whether (nonlinear) SFA components are used for reconstruction
+        self.reconstruct_with_sfa = reconstruct_with_sfa
+        # Indicates how to scale the slow part
+        self.slow_feature_scaling_method = slow_feature_scaling_method
+
+        # Default verbose value if none is explicity provided to the class methods
+        self.verbose = verbose
+
+        # Dimensionality of the data after the expansion function
+        self.expanded_dim = None
+
+        # The following variables are for internal use only (available after training on a single batch only)
+        self.x_mean = None
+        self.sfa_x_mean = None
+        self.sfa_x_std = None
+
+    @staticmethod
+    def is_trainable():
+        return True
+
+    # TODO: should train_mode be renamed training_mode?
+    def _train(self, x, block_size=None, train_mode=None, node_weights=None, edge_weights=None, verbose=None, **argv):
+        """Trains an iGSFA node on data 'x'
+
+        The parameters:  block_size, train_mode, node_weights, and edge_weights are passed to the training function of
+        the corresponding gsfa node inside iGSFA (node.gsfa_node).
+        """
+        self.input_dim = x.shape[1]
+        if verbose is None:
+            verbose = self.verbose
+
+        if self.output_dim is None:
+            self.output_dim = self.input_dim
+
+        if verbose:
+            print("Training iGSFANode...")
+
+        if (not self.reconstruct_with_sfa) and (self.slow_feature_scaling_method in [None, "data_dependent"]):
+            self.multiple_train(x, block_size=block_size, train_mode=train_mode, node_weights=node_weights,
+                                edge_weights=edge_weights)
+            return
+
+        if (not self.reconstruct_with_sfa) and (self.slow_feature_scaling_method not in [None, "data_dependent"]):
+            er = "'reconstruct_with_sfa' (" + str(self.reconstruct_with_sfa) + ") must be True when the scaling" + \
+                 "method (" + str(self.slow_feature_scaling_method) + ") is neither 'None' not 'data_dependent'"
+            raise Exception(er)
+        # else continue using the regular method:
+
+        # Remove mean before expansion
+        self.x_mean = x.mean(axis=0)
+        x_zm = x - self.x_mean
+
+        # Reorder or pre-process the data before it is expanded, but only if there is really an expansion
+        if self.pre_expansion_node_class and self.exp_node:
+            self.pre_expansion_node = self.pre_expansion_node_class(output_dim=self.pre_expansion_output_dim)
+            # reasonable options are pre_expansion_node_class = GSFANode or WhitheningNode
+            self.pre_expansion_node.train(x_zm, block_size=block_size,
+                                          train_mode=train_mode)  # Some arguments might not be necessary
+            self.pre_expansion_node.stop_training()
+            x_pre_exp = self.pre_expansion_node.execute(x_zm)
+        else:
+            x_pre_exp = x_zm
+
+        # Expand data
+        if self.exp_node:
+            if verbose:
+                print("expanding x...")
+            exp_x = self.exp_node.execute(x_pre_exp)
+        else:
+            exp_x = x_pre_exp
+
+        self.expanded_dim = exp_x.shape[1]
+
+        if self.max_length_slow_part is None:
+            sfa_output_dim = min(self.expanded_dim, self.output_dim)
+        else:
+            sfa_output_dim = min(self.max_length_slow_part, self.expanded_dim, self.output_dim)
+
+        if isinstance(self.delta_threshold, int):
+            sfa_output_dim = min(sfa_output_dim, self.delta_threshold)
+            sfa_output_dim = max(1, sfa_output_dim)
+
+        # Apply SFA to expanded data
+        self.sfa_node = GSFANode(output_dim=sfa_output_dim, verbose=verbose)
+        # TODO: train_params is only present if patch_mdp has been imported, is this a bug?
+        self.sfa_node.train_params(exp_x, params={"block_size": block_size, "train_mode": train_mode,
+                                                  "node_weights": node_weights,
+                                                  "edge_weights": edge_weights})
+        self.sfa_node.stop_training()
+        if verbose:
+            print("self.sfa_node.d", self.sfa_node.d)
+
+        # Decide how many slow features are preserved (either use Delta_T=delta_threshold when
+        # delta_threshold is a float, or preserve delta_threshold features when delta_threshold is an integer)
+        if isinstance(self.delta_threshold, float):
+            # here self.max_length_slow_part should be considered
+            self.num_sfa_features_preserved = (self.sfa_node.d <= self.delta_threshold).sum()
+        elif isinstance(self.delta_threshold, int):
+            # here self.max_length_slow_part should be considered
+            self.num_sfa_features_preserved = self.delta_threshold
+            if self.delta_threshold > self.output_dim:
+                er = "The provided integer delta_threshold %d is larger than the allowed output dimensionality %d" % \
+                     (self.delta_threshold, self.output_dim)
+                raise Exception(er)
+            if self.max_length_slow_part is not None and self.delta_threshold > self.max_length_slow_part:
+                er = "The provided integer delta_threshold %d" % self.delta_threshold + \
+                     " is larger than the given upper bound on the size of the slow part (max_length_slow_part) %d" % \
+                     self.max_length_slow_part
+                raise Exception(er)
+
+        else:
+            ex = "Cannot handle type of self.delta_threshold"
+            raise Exception(ex)
+
+        if self.num_sfa_features_preserved > self.output_dim:
+            self.num_sfa_features_preserved = self.output_dim
+
+        SFANode_reduce_output_dim(self.sfa_node, self.num_sfa_features_preserved)
+        if verbose:
+            print("sfa execute...")
+        sfa_x = self.sfa_node.execute(exp_x)
+
+        # normalize sfa_x
+        self.sfa_x_mean = sfa_x.mean(axis=0)
+        self.sfa_x_std = sfa_x.std(axis=0)
+        if verbose:
+            print("self.sfa_x_mean=", self.sfa_x_mean)
+            print("self.sfa_x_std=", self.sfa_x_std)
+        if (self.sfa_x_std == 0).any():
+            er = "zero-component detected"
+            raise Exception(er)
+        n_sfa_x = (sfa_x - self.sfa_x_mean) / self.sfa_x_std
+
+        if self.reconstruct_with_sfa:
+            x_pca = x_zm
+
+            # approximate input linearly, done inline to preserve node for future use
+            if verbose:
+                print("training linear regression...")
+            self.lr_node = mdp.nodes.LinearRegressionNode()
+            # Notice that the input "x"=n_sfa_x and the output to learn is "y" = x_pca
+            self.lr_node.train(n_sfa_x, x_pca)
+            self.lr_node.stop_training()
+            x_pca_app = self.lr_node.execute(n_sfa_x)
+            x_app = x_pca_app
+        else:
+            x_app = numpy.zeros_like(x_zm)
+
+        # Remove linear approximation
+        sfa_removed_x = x_zm - x_app
+
+        # TODO:Compute variance removed by linear approximation
+        if verbose:
+            print("ranking method...")
+        # AKA Laurenz method for feature scaling( +rotation)
+        if self.reconstruct_with_sfa and self.slow_feature_scaling_method == "QR_decomposition":
+            M = self.lr_node.beta[1:, :].T  # bias is used by default, we do not need to consider it
+            Q, R = numpy.linalg.qr(M)
+            self.Q = Q
+            self.R = R
+            self.Rpinv = pinv(R)
+            s_n_sfa_x = numpy.dot(n_sfa_x, R.T)
+        # AKA my method for feature scaling (no rotation)
+        elif self.reconstruct_with_sfa and (self.slow_feature_scaling_method == "sensitivity_based"):
+            beta = self.lr_node.beta[1:, :]  # bias is used by default, we do not need to consider it
+            sens = (beta ** 2).sum(axis=1)
+            self.magn_n_sfa_x = sens ** 0.5
+            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
+            if verbose:
+                print("method: sensitivity_based enforced")
+        elif self.slow_feature_scaling_method is None:
+            self.magn_n_sfa_x = 1.0
+            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
+            if verbose:
+                print("method: constant amplitude for all slow features")
+        elif self.slow_feature_scaling_method == "data_dependent":
+            if verbose:
+                print("skiped data_dependent")
+        else:
+            er = "unknown slow feature scaling method= " + str(self.slow_feature_scaling_method) + \
+                 " for reconstruct_with_sfa= " + str(self.reconstruct_with_sfa)
+            raise Exception(er)
+
+        print("training PCA...")
+        pca_output_dim = self.output_dim - self.num_sfa_features_preserved
+        # This allows training of PCA when pca_out_dim is zero
+        self.pca_node = mdp.nodes.PCANode(output_dim=max(1, pca_output_dim))  # reduce=True
+        self.pca_node.train(sfa_removed_x)
+        self.pca_node.stop_training()
+        PCANode_reduce_output_dim(self.pca_node, pca_output_dim, verbose=False)
+
+        # TODO:check that pca_out_dim > 0
+        if verbose:
+            print("executing PCA...")
+
+        pca_x = self.pca_node.execute(sfa_removed_x)
+
+        if self.slow_feature_scaling_method == "data_dependent":
+            if pca_output_dim > 0:
+                self.magn_n_sfa_x = 1.0 * numpy.median(
+                    self.pca_node.d) ** 0.5  # WARNING, why did I have 5.0 there? it is supposed to be 1.0
+            else:
+                self.magn_n_sfa_x = 1.0
+            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x  # Scale according to ranking
+            if verbose:
+                print("method: data dependent")
+
+        if self.pca_node.output_dim + self.num_sfa_features_preserved < self.output_dim:
+            er = "Error, the number of features computed is SMALLER than the output dimensionality of the node: " + \
+                 "self.pca_node.output_dim=" + str(self.pca_node.output_dim) + ", self.num_sfa_features_preserved=" + \
+                 str(self.num_sfa_features_preserved) + ", self.output_dim=" + str(self.output_dim)
+            raise Exception(er)
+
+        # Finally, the output is the concatenation of scaled slow features and remaining pca components
+        sfa_pca_x = numpy.concatenate((s_n_sfa_x, pca_x), axis=1)
+
+        sfa_pca_x_truncated = sfa_pca_x[:, 0:self.output_dim]
+
+        # Compute explained variance from amplitudes of output compared to amplitudes of input
+        # Only works because amplitudes of SFA are scaled to be equal to explained variance, because PCA is
+        # a rotation, and because data has zero mean
+        self.evar = (sfa_pca_x_truncated ** 2).sum() / (x_zm ** 2).sum()
+        if verbose:
+            print("s_n_sfa_x:", s_n_sfa_x, "pca_x:", pca_x)
+            print("sfa_pca_x_truncated:", sfa_pca_x_truncated, "x_zm:", x_zm)
+            print("Variance(output) / Variance(input) is ", self.evar)
+        self.stop_training()
+
+    def multiple_train(self, x, block_size=None, train_mode=None, node_weights=None,
+                       edge_weights=None, verbose=None):
+        """This function should not be called directly. Use instead the train method, which will decide whether
+        multiple-training is enabled, and call this function if needed. """
+        # TODO: is the following line needed? or also self.set_input_dim? or self._input_dim?
+        self.input_dim = x.shape[1]
+        if verbose is None:
+            verbose = self.verbose
+
+        if verbose:
+            print("Training iGSFANode (multiple train method)...")
+
+        # Data mean is ignored by the multiple train method
+        if self.x_mean is None:
+            self.x_mean = numpy.zeros(self.input_dim)
+        x_zm = x
+
+        # Reorder or pre-process the data before it is expanded, but only if there is really an expansion.
+        # WARNING, why the last condition???
+        if self.pre_expansion_node_class and self.exp_node:
+            er = "Unexpected parameters"
+            raise Exception(er)
+        else:
+            x_pre_exp = x_zm
+
+        if self.exp_node:
+            if verbose:
+                print("expanding x...")
+            exp_x = self.exp_node.execute(x_pre_exp)  # x_zm
+        else:
+            exp_x = x_pre_exp
+
+        self.expanded_dim = exp_x.shape[1]
+
+        if self.max_length_slow_part is None:
+            sfa_output_dim = min(self.expanded_dim, self.output_dim)
+        else:
+            sfa_output_dim = min(self.max_length_slow_part, self.expanded_dim, self.output_dim)
+
+        if isinstance(self.delta_threshold, int):
+            sfa_output_dim = min(sfa_output_dim, self.delta_threshold)
+            sfa_output_dim = max(1, sfa_output_dim)
+
+        # Apply SFA to expanded data
+        if self.sfa_node is None:
+            self.sfa_node = GSFANode(output_dim=sfa_output_dim, verbose=verbose)
+        self.sfa_x_mean = 0
+        self.sfa_x_std = 1.0
+
+        self.sfa_node.train_params(exp_x, params={"block_size": block_size, "train_mode": train_mode,
+                                                  "node_weights": node_weights,
+                                                  "edge_weights": edge_weights})
+
+        if verbose:
+            print("training PCA...")
+        pca_output_dim = self.output_dim
+        if self.pca_node is None:
+            # WARNING: WHY WAS I EXTRACTING ALL PCA COMPONENTS!!?? INEFFICIENT!!!!
+            self.pca_node = mdp.nodes.PCANode(output_dim=pca_output_dim)  # reduce=True) #output_dim = pca_out_dim)
+        sfa_removed_x = x
+        self.pca_node.train(sfa_removed_x)
+
+    def _stop_training(self, verbose=None):
+        if verbose is None:
+            verbose = self.verbose
+        if self.reconstruct_with_sfa or (self.slow_feature_scaling_method not in [None, "data_dependent"]):
+            return
+        # else, continue with multi-train method
+
+        self.sfa_node.stop_training()
+        if verbose:
+            print("self.sfa_node.d", self.sfa_node.d)
+        self.pca_node.stop_training()
+
+        # Decide how many slow features are preserved (either use Delta_T=delta_threshold when
+        # delta_threshold is a float, or preserve delta_threshold features when delta_threshold is an integer)
+        if isinstance(self.delta_threshold, float):
+            # here self.max_length_slow_part should be considered
+            self.num_sfa_features_preserved = (self.sfa_node.d <= self.delta_threshold).sum()
+        elif isinstance(self.delta_threshold, int):
+            # here self.max_length_slow_part should be considered
+            self.num_sfa_features_preserved = self.delta_threshold
+            if self.delta_threshold > self.output_dim:
+                er = "The provided integer delta_threshold %d is larger than the allowed output dimensionality %d" % \
+                     (self.delta_threshold, self.output_dim)
+                raise Exception(er)
+            if self.max_length_slow_part is not None and self.delta_threshold > self.max_length_slow_part:
+                er = "The provided integer delta_threshold %d" % self.delta_threshold + \
+                     " is larger than the given upper bound on the size of the slow part (max_length_slow_part) %d" % \
+                     self.max_length_slow_part
+                raise Exception(er)
+        else:
+            ex = "Cannot handle type of self.delta_threshold:" + str(type(self.delta_threshold))
+            raise Exception(ex)
+
+        if self.num_sfa_features_preserved > self.output_dim:
+            self.num_sfa_features_preserved = self.output_dim
+
+        SFANode_reduce_output_dim(self.sfa_node, self.num_sfa_features_preserved)
+        if verbose:
+            print("size of slow part:", self.num_sfa_features_preserved)
+
+        final_pca_node_output_dim = self.output_dim - self.num_sfa_features_preserved
+        if final_pca_node_output_dim > self.pca_node.output_dim:
+            er = "Error, the number of features computed is SMALLER than the output dimensionality of the node: " + \
+                 "self.pca_node.output_dim=" + str(self.pca_node.output_dim) + ", self.num_sfa_features_preserved=" + \
+                 str(self.num_sfa_features_preserved) + ", self.output_dim=" + str(self.output_dim)
+            raise Exception(er)
+        PCANode_reduce_output_dim(self.pca_node, final_pca_node_output_dim, verbose=False)
+
+        if verbose:
+            print("self.pca_node.d", self.pca_node.d)
+            print("ranking method...")
+        if self.slow_feature_scaling_method is None:
+            self.magn_n_sfa_x = 1.0
+            if verbose:
+                print("method: constant amplitude for all slow features")
+        elif self.slow_feature_scaling_method == "data_dependent":
+            # SFA components have an std equal to that of the least significant principal component
+            if self.pca_node.d.shape[0] > 0:
+                self.magn_n_sfa_x = 1.0 * numpy.median(self.pca_node.d) ** 0.5
+                # 100.0 * self.pca_node.d[-1] ** 0.5 + 0.0 # Experiment: use 5.0 instead of 1.0
+            else:
+                self.magn_n_sfa_x = 1.0
+            if verbose:
+                print("method: data dependent")
+        else:
+            er = "Unknown slow feature scaling method" + str(self.slow_feature_scaling_method)
+            raise Exception(er)
+        self.evar = self.pca_node.explained_variance
+
+    @staticmethod
+    def _is_invertible():
+        return True
+
+    def _execute(self, x):
+        """Extracts iGSFA features from some data. The node must have been already trained. """
+        x_zm = x - self.x_mean
+
+        if self.pre_expansion_node:
+            x_pre_exp = self.pre_expansion_node.execute(x_zm)
+        else:
+            x_pre_exp = x_zm
+
+        if self.exp_node:
+            exp_x = self.exp_node.execute(x_pre_exp)
+        else:
+            exp_x = x_pre_exp
+
+        sfa_x = self.sfa_node.execute(exp_x)
+
+        n_sfa_x = (sfa_x - self.sfa_x_mean) / self.sfa_x_std
+
+        if self.reconstruct_with_sfa:
+            # approximate input linearly, done inline to preserve node
+            x_pca_app = self.lr_node.execute(n_sfa_x)
+            x_app = x_pca_app
+        else:
+            x_app = numpy.zeros_like(x_zm)
+
+        # Remove linear approximation from the centered data
+        sfa_removed_x = x_zm - x_app
+
+        # Laurenz method for feature scaling( +rotation)
+        if self.reconstruct_with_sfa and self.slow_feature_scaling_method == "QR_decomposition":
+            s_n_sfa_x = numpy.dot(n_sfa_x, self.R.T)
+        # My method for feature scaling (no rotation)
+        elif self.reconstruct_with_sfa and self.slow_feature_scaling_method == "sensitivity_based":
+            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
+        elif self.slow_feature_scaling_method is None:
+            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
+            # Scale according to ranking
+        elif self.slow_feature_scaling_method == "data_dependent":
+            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
+        else:
+            er = "unknown feature scaling method" + str(self.slow_feature_scaling_method)
+            raise Exception(er)
+
+        # Apply PCA to sfa removed data
+        if self.pca_node.output_dim > 0:
+            pca_x = self.pca_node.execute(sfa_removed_x)
+        else:
+            # No reconstructive components present
+            pca_x = numpy.zeros((x.shape[0], 0))
+
+        # Finally output is the concatenation of scaled slow features and remaining pca components
+        sfa_pca_x = numpy.concatenate((s_n_sfa_x, pca_x), axis=1)
+
+        return sfa_pca_x  # sfa_pca_x_truncated
+
+    def _inverse(self, y, linear_inverse=True):
+        """This method approximates an inverse function to the feature extraction.
+
+        if linear_inverse is True, a linear method is used. Otherwise, a gradient-based non-linear method is used.
+        """
+        if linear_inverse:
+            return self.linear_inverse(y)
+        else:
+            return self.non_linear_inverse(y)
+
+    def non_linear_inverse(self, y, verbose=None):
+        """Non-linear inverse approximation method.
+
+        This method is experimental and should be used with care.
+        """
+        if verbose is None:
+            verbose = self.verbose
+        x_lin = self.linear_inverse(y)
+        rmse_lin = ((y - self.execute(x_lin)) ** 2).sum(axis=1).mean() ** 0.5
+        # scipy.optimize.leastsq(func, x0, args=(), Dfun=None, full_output=0, col_deriv=0, ftol=1.49012e-08,
+        # xtol=1.49012e-08, gtol=0.0, maxfev=0, epsfcn=0.0, factor=100, diag=None)
+        x_nl = numpy.zeros_like(x_lin)
+        y_dim = y.shape[1]
+        x_dim = x_lin.shape[1]
+        if y_dim < x_dim:
+            num_zeros_filling = x_dim - y_dim
+        else:
+            num_zeros_filling = 0
+        if verbose:
+            print("x_dim=", x_dim, "y_dim=", y_dim, "num_zeros_filling=", num_zeros_filling)
+        y_long = numpy.zeros(y_dim + num_zeros_filling)
+
+        for i, y_i in enumerate(y):
+            y_long[0:y_dim] = y_i
+            if verbose:
+                print("x_0=", x_lin[i])
+                print("y_long=", y_long)
+            plsq = scipy.optimize.leastsq(func=f_residual, x0=x_lin[i], args=(self, y_long), full_output=False)
+            x_nl_i = plsq[0]
+            if verbose:
+                print("x_nl_i=", x_nl_i, "plsq[1]=", plsq[1])
+            if plsq[1] != 2:
+                print("Quitting: plsq[1]=", plsq[1])
+                # quit()
+            x_nl[i] = x_nl_i
+            if verbose:
+                print("|E_lin(%d)|=" % i, ((y_i - self.execute(x_lin[i].reshape((1, -1)))) ** 2).sum() ** 0.5)
+                print("|E_nl(%d)|=" % i, ((y_i - self.execute(x_nl_i.reshape((1, -1)))) ** 2).sum() ** 0.5)
+        rmse_nl = ((y - self.execute(x_nl)) ** 2).sum(axis=1).mean() ** 0.5
+        if verbose:
+            print("rmse_lin(all samples)=", rmse_lin, "rmse_nl(all samples)=", rmse_nl)
+        return x_nl
+
+    def linear_inverse(self, y, verbose=None):
+        """Linear inverse approximation method. """
+        if verbose is None:
+            verbose = self.verbose
+        num_samples = y.shape[0]
+        if y.shape[1] != self.output_dim:
+            er = "Serious dimensionality inconsistency:", y.shape[0], self.output_dim
+            raise Exception(er)
+
+        sfa_pca_x_full = numpy.zeros(
+            (num_samples, self.pca_node.output_dim + self.num_sfa_features_preserved))  # self.input_dim
+        sfa_pca_x_full[:, 0:self.output_dim] = y
+
+        s_n_sfa_x = sfa_pca_x_full[:, 0:self.num_sfa_features_preserved]
+        pca_x = sfa_pca_x_full[:, self.num_sfa_features_preserved:]
+
+        if pca_x.shape[1] > 0:
+            sfa_removed_x = self.pca_node.inverse(pca_x)
+        else:
+            sfa_removed_x = numpy.zeros((num_samples, self.input_dim))
+
+        # AKA Laurenz method for feature scaling (+rotation)
+        if self.reconstruct_with_sfa and self.slow_feature_scaling_method == "QR_decomposition":
+            n_sfa_x = numpy.dot(s_n_sfa_x, self.Rpinv.T)
+        else:
+            n_sfa_x = s_n_sfa_x / self.magn_n_sfa_x
+
+        # sfa_x = n_sfa_x * self.sfa_x_std + self.sfa_x_mean
+        if self.reconstruct_with_sfa:
+            x_pca_app = self.lr_node.execute(n_sfa_x)
+            x_app = x_pca_app
+        else:
+            x_app = numpy.zeros_like(sfa_removed_x)
+
+        x_zm = sfa_removed_x + x_app
+
+        x = x_zm + self.x_mean
+
+        if verbose:
+            print("Data_variance(x_zm)=", data_variance(x_zm))
+            print("Data_variance(x_app)=", data_variance(x_app))
+            print("Data_variance(sfa_removed_x)=", data_variance(sfa_removed_x))
+            print("x_app.mean(axis=0)=", x_app)
+            print("x[0]=", x[0])
+            print("zm_x[0]=", zm_x[0])
+            print("exp_x[0]=", exp_x[0])
+            print("s_x_1[0]=", s_x_1[0])
+            print("proj_sfa_x[0]=", proj_sfa_x[0])
+            print("sfa_removed_x[0]=", sfa_removed_x[0])
+            print("pca_x[0]=", pca_x[0])
+            print("n_pca_x[0]=", n_pca_x[0])
+            print("sfa_x[0]=", sfa_x[0])
+
+        return x
+
+
+def SFANode_reduce_output_dim(sfa_node, new_output_dim, verbose=False):
+    """ This function modifies an already trained SFA node (or GSFA node),
+    reducing the number of preserved SFA features to new_output_dim features.
+    The modification is done in place
+    """
+    if verbose:
+        print("Updating the output dimensionality of SFA node")
+    if new_output_dim > sfa_node.output_dim:
+        er = "Can only reduce output dimensionality of SFA node, not increase it (%d > %d)" % \
+             (new_output_dim, sfa_node.output_dim)
+        raise Exception(er)
+    if verbose:
+        print("Before: sfa_node.d.shape=", sfa_node.d.shape, " sfa_node.sf.shape=", sfa_node.sf.shape)
+        print("sfa_node._bias.shape=", sfa_node._bias.shape)
+    sfa_node.d = sfa_node.d[:new_output_dim]
+    sfa_node.sf = sfa_node.sf[:, :new_output_dim]
+    sfa_node._bias = sfa_node._bias[:new_output_dim]
+    sfa_node._output_dim = new_output_dim
+    if verbose:
+        print("After: sfa_node.d.shape=", sfa_node.d.shape, " sfa_node.sf.shape=", sfa_node.sf.shape)
+        print(" sfa_node._bias.shape=", sfa_node._bias.shape)
+
+
+def PCANode_reduce_output_dim(pca_node, new_output_dim, verbose=False):
+    """ This function modifies an already trained PCA node,
+    reducing the number of preserved SFA features to new_output_dim features.
+    The modification is done in place. Also the explained variance field is updated
+    """
+    if verbose:
+        print("Updating the output dimensionality of PCA node")
+    if new_output_dim > pca_node.output_dim:
+        er = "Can only reduce output dimensionality of PCA node, not increase it"
+        raise Exception(er)
+    if verbose:
+        print("Before: pca_node.d.shape=", pca_node.d.shape, " pca_node.v.shape=", pca_node.v.shape)
+        print(" pca_node.avg.shape=", pca_node.avg.shape)
+
+    # if new_output_dim > 0:
+    original_total_variance = pca_node.d.sum()
+    original_explained_variance = pca_node.explained_variance
+    pca_node.d = pca_node.d[0:new_output_dim]
+    pca_node.v = pca_node.v[:, 0:new_output_dim]
+    # pca_node.avg is not affected by this method!
+    pca_node._output_dim = new_output_dim
+    pca_node.explained_variance = original_explained_variance * pca_node.d.sum() / original_total_variance
+    # else:
+
+    if verbose:
+        print("After: pca_node.d.shape=", pca_node.d.shape, " pca_node.v.shape=", pca_node.v.shape)
+        print(" pca_node.avg.shape=", pca_node.avg.shape)
+
+
+# Computes output errors dimension by dimension for a single sample: y - node.execute(x_app)
+# The library fails when dim(x_app) > dim(y), thus filling of x_app with zeros is recommended
+def f_residual(x_app_i, node, y_i):
+    res_long = numpy.zeros_like(y_i)
+    y_i = y_i.reshape((1, -1))
+    y_i_short = y_i[:, 0:node.output_dim]
+    res = (y_i_short - node.execute(x_app_i.reshape((1, -1)))).flatten()
+    res_long[0:len(res)] = res
+    return res_long
+
+
+#########################################################################################################
+#   EXAMPLES THAT SHOW HOW GSFA CAN BE USED                                                             #
+#########################################################################################################
+
+def example_clustered_graph():
+    print("\n**************************************************************************")
+    print("*Example of training GSFA using a clustered graph")
+    cluster_size = 20
+    num_clusters = 5
+    num_samples = cluster_size * num_clusters
+    dim = 20
+    output_dim = 2
+    x = numpy.random.normal(size=(num_samples, dim))
+    x += 0.1 * numpy.arange(num_samples).reshape((num_samples, 1))
+
+    print("x=", x)
+
+    GSFA_n = GSFANode(output_dim=output_dim)
+
+    def identity(xx):
+        return xx
+
+    def norm2(xx):  # Computes the norm of each sample returning an Nx1 array
+        return ((xx ** 2).sum(axis=1) ** 0.5).reshape((-1, 1))
+
+    Exp_n = mdp.nodes.GeneralExpansionNode([identity, norm2])
+
+    exp_x = Exp_n.execute(x)  # Expanded data
+    GSFA_n.train(exp_x, train_mode="clustered", block_size=cluster_size)
+    GSFA_n.stop_training()
+
+    print("GSFA_n.d=", GSFA_n.d)
+
+    y = GSFA_n.execute(Exp_n.execute(x))
+    print("y", y)
+    print("Standard delta values of output features y:", comp_delta(y))
+
+    x_test = numpy.random.normal(size=(num_samples, dim))
+    x_test += 0.1 * numpy.arange(num_samples).reshape((num_samples, 1))
+    y_test = GSFA_n.execute(Exp_n.execute(x_test))
+    print("y_test", y_test)
+    print("Standard delta values of output features y_test:", comp_delta(y_test))
+
+
+def example_pathological_outputs(experiment):
+    print("\n **************************************************************************")
+    print("*Pathological responses. Experiment on graph with weakly connected samples")
+    x = numpy.random.normal(size=(20, 19))
+    x2 = numpy.random.normal(size=(20, 19))
+
+    l = numpy.random.normal(size=20)
+    l -= l.mean()
+    l /= l.std()
+    l.sort()
+
+    half_width = 3
+
+    v = numpy.ones(20)
+    e = {}
+    for t in range(19):
+        e[(t, t + 1)] = 1.0
+    e[(0, 0)] = 0.5
+    e[(19, 19)] = 0.5
+    train_mode = "graph"
+
+    # experiment = 0 #Select the experiment to perform, from 0 to 11
+    print("experiment", experiment)
+    if experiment == 0:
+        exp_title = "Original linear SFA graph"
+    elif experiment == 1:
+        v[0] = 10.0
+        v[10] = 0.1
+        v[19] = 10.0
+        exp_title = "Modified node weights 1"
+    elif experiment == 2:
+        v[0] = 10.0
+        v[19] = 0.1
+        exp_title = "Modified node weights 2"
+    elif experiment == 3:
+        e[(0, 1)] = 0.1
+        e[(18, 19)] = 10.0
+        exp_title = "Modified edge weights 3"
+    elif experiment == 4:
+        e[(0, 1)] = 0.01
+        e[(18, 19)] = 0.01
+        e[(15, 17)] = 0.5
+        e[(16, 18)] = 0.5
+        e[(12, 14)] = 0.5
+        e[(3, 5)] = 0.5
+        e[(4, 6)] = 0.5
+        e[(5, 7)] = 0.5
+
+        # e[(1,2)] = 0.1
+        exp_title = "Modified edge weights 4"
+    elif experiment == 5:
+        e[(10, 11)] = 0.02
+        e[(1, 2)] = 0.02
+        e[(3, 5)] = 1.0
+        e[(7, 9)] = 1.0
+        e[(17, 19)] = 1.0
+        e[(14, 16)] = 1.0
+
+        exp_title = "Modified edge weights 5"
+    elif experiment == 6:
+        e[(6, 7)] = 0.1
+        e[(5, 6)] = 0.1
+        exp_title = "Modified edge weights 6"
+    elif experiment == 7:
+        e = {}
+        for j1 in range(19):
+            for j2 in range(j1 + 1, 20):
+                e[(j1, j2)] = 1 / (l[j2] - l[j1] + 0.00005)
+        exp_title = "Modified edge weights for labels as w12 = 1/(l2-l1+0.00005) 7"
+    elif experiment == 8:
+        e = {}
+        for j1 in range(19):
+            for j2 in range(j1 + 1, 20):
+                e[(j1, j2)] = numpy.exp(-0.25 * (l[j2] - l[j1]) ** 2)
+        exp_title = "Modified edge weights for labels as w12 = exp(-0.25*(l2-l1)**2) 8"
+    elif experiment == 9:
+        e = {}
+        for j1 in range(19):
+            for j2 in range(j1 + 1, 20):
+                if l[j2] - l[j1] < 0.6:
+                    e[(j1, j2)] = 1 / (l[j2] - l[j1] + 0.00005)
+        exp_title = "Modified edge weights w12 = 1/(l2-l1+0.00005), for l2-l1<0.6 9"
+    elif experiment == 10:
+        exp_title = "Mirroring training graph, w=%d" % half_width + "10"
+        train_mode = "smirror_window%d" % half_width
+        e = {}
+    elif experiment == 11:
+        exp_title = "Node weight adjustment training graph, w=%d " % half_width + "11"
+        train_mode = "window%d" % half_width
+        e = {}
+    else:
+        er = "Unknown experiment " + str(experiment)
+        raise Exception(er)
+
+    n = GSFANode(output_dim=5)
+    if experiment in (10, 11):
+        n.train(x, train_mode=train_mode)
+    else:
+        n.train(x, train_mode="graph", node_weights=v, edge_weights=e)
+    n.stop_training()
+
+    print("/" * 20, "Brute delta values of GSFA features (training/test):")
+    y = n.execute(x)
+    y2 = n.execute(x2)
+    if e != {}:
+        print(graph_delta_values(y, e))
+        print(graph_delta_values(y2, e))
+
+    D = numpy.zeros(20)
+    for (j1, j2) in e:
+        D[j1] += e[(j1, j2)] / 2.0
+        D[j2] += e[(j1, j2)] / 2.0
+
+    import matplotlib as mpl
+    mpl.use('Qt4Agg')
+    import matplotlib.pyplot as plt
+
+    plt.figure()
+    plt.title("Overfitted outputs on training data, v (node weights)=" + str(v))
+    plt.xlabel(exp_title + "\n With D (half the sum of all edges from/to each vertex)=" + str(D))
+    plt.xticks(numpy.arange(0, 20, 1))
+    plt.plot(y)
+    if experiment in (6, 7, 8):
+        if y[0, 0] > 0:
+            l *= -1
+        plt.plot(l, "*")
+    plt.show()
+
+
+def example_continuous_edge_weights():
+    print("\n**************************************************************************")
+    print("*Testing continuous edge weigths w_{n,n'} = 1/(|l_n'-l_n|+k)")
+    x = numpy.random.normal(size=(20, 19))
+    x2 = numpy.random.normal(size=(20, 19))
+
+    l = numpy.random.normal(size=20)
+    l -= l.mean()
+    l /= l.std()
+    l.sort()
+    k = 0.0001
+
+    v = numpy.ones(20)
+    e = {}
+    for n1 in range(20):
+        for n2 in range(20):
+            if n1 != n2:
+                e[(n1, n2)] = 1.0 / (numpy.abs(l[n2] - l[n1]) + k)
+
+    exp_title = "Original linear SFA graph"
+    n = GSFANode(output_dim=5)
+    n.train(x, train_mode="graph", node_weights=v, edge_weights=e)
+    n.stop_training()
+
+    print("/" * 20, "Brute delta values of GSFA features (training/test):")
+    y = n.execute(x)
+    y2 = n.execute(x2)
+    if e != {}:
+        print(graph_delta_values(y, e))
+        print(graph_delta_values(y2, e))
+
+    D = numpy.zeros(20)
+    for (j1, j2) in e:
+        D[j1] += e[(j1, j2)] / 2.0
+        D[j2] += e[(j1, j2)] / 2.0
+
+    import matplotlib as mpl
+    mpl.use('Qt4Agg')
+    import matplotlib.pyplot as plt
+
+    plt.figure()
+    plt.title("Overfitted outputs on training data,v=" + str(v))
+    plt.xlabel(exp_title + "\n With D=" + str(D))
+    plt.xticks(numpy.arange(0, 20, 1))
+    plt.plot(y)
+    plt.plot(l, "*")
+    plt.show()
+
+
+########################################################################################
+#   AN EXAMPLE OF HOW iGSFA CAN BE USED                                                #
+########################################################################################
+
+def example_iGSFA():
+    print("\n\n**************************************************************************")
+    print("*Example of training iGSFA on random data")
+    num_samples = 1000
+    dim = 20
+    verbose = False
+    x = numpy.random.normal(size=(num_samples, dim))
+    x[:, 0] += 2.0 * numpy.arange(num_samples) / num_samples
+    x[:, 1] += 1.0 * numpy.arange(num_samples) / num_samples
+    x[:, 2] += 0.5 * numpy.arange(num_samples) / num_samples
+
+    x_test = numpy.random.normal(size=(num_samples, dim))
+    x_test[:, 0] += 2.0 * numpy.arange(num_samples) / num_samples
+    x_test[:, 1] += 1.0 * numpy.arange(num_samples) / num_samples
+    x_test[:, 2] += 0.5 * numpy.arange(num_samples) / num_samples
+
+    import cuicuilco.patch_mdp
+    from cuicuilco.sfa_libs import zero_mean_unit_var
+    print("Node creation and training")
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=False, slow_feature_scaling_method="data_dependent",
+                  verbose=verbose)
+    n.train(x, train_mode="regular")
+    n.stop_training()
+
+    y = n.execute(x)
+    y_test = n.execute(x_test)
+
+    print("y=", y)
+    print("y_test=", y_test)
+    print("Standard delta values of output features y:", comp_delta(y))
+    print("Standard delta values of output features y_test:", comp_delta(y_test))
+    y_norm = zero_mean_unit_var(y)
+    y_test_norm = zero_mean_unit_var(y_test)
+    print("Standard delta values of output features y after constraint enforcement:", comp_delta(y_norm))
+    print("Standard delta values of output features y_test after constraint enforcement:", comp_delta(y_test_norm))
+
+
+if __name__ == "__main__":
+    for experiment_number in range(0, 12):
+        example_pathological_outputs(experiment=experiment_number)
+    example_continuous_edge_weights()
+    example_clustered_graph()
+    example_iGSFA()

--- a/mdp/nodes/gsfa_nodes.py
+++ b/mdp/nodes/gsfa_nodes.py
@@ -26,6 +26,11 @@ from mdp import numx, NodeException, TrainingException
 from mdp.utils import (mult, symeig, pinv, CovarianceMatrix, SymeigException)
 from mdp.nodes import GeneralExpansionNode
 
+# For Python 2 & 3 compatibility
+try:
+  basestring
+except NameError:
+  basestring = str
 
 class GSFANode(mdp.Node):
     """ This node implements "Graph-Based SFA (GSFA)", which is the main component of hierarchical GSFA (HGSFA).
@@ -1139,68 +1144,6 @@ class CovDCovMatrix(object):
         return self.cov_mtx, self.avg, self.dcov_mtx
 
 
-# ####### Helper functions for parallel processing and CovDcovMatrices #########
-
-# This function is used by patch_mdp
-# def compute_cov_matrix(x, verbose=False):
-#     print("PCov")
-#     if verbose:
-#         print("Computation Began!!! **********************************************************")
-#         sys.stdout.flush()
-#     covmtx = CovarianceMatrix(bias=True)
-#     covmtx.update(x)
-#     if verbose:
-#         print("Computation Ended!!! **********************************************************")
-#         sys.stdout.flush()
-#     return covmtx
-#
-#
-# def compute_cov_dcov_matrix_clustered(params, verbose=False):
-#     print("PComp")
-#     if verbose:
-#         print("Computation Began!!! **********************************************************")
-#         sys.stdout.flush()
-#     x, block_size, weight = params
-#     covdcovmtx = CovDCovMatrix()
-#     covdcovmtx.update_clustered_homogeneous_block_sizes(x, block_size=block_size, weight=weight)
-#     if verbose:
-#         print("Computation Ended!!! **********************************************************")
-#         sys.stdout.flush()
-#     return covdcovmtx
-#
-#
-# def compute_cov_dcov_matrix_serial(params, verbose=False):
-#     print("PSeq")
-#     if verbose:
-#         print("Computation Began!!! **********************************************************")
-#         sys.stdout.flush()
-#     x, block_size = params
-#     covdcovmtx = CovDCovMatrix()
-#     covdcovmtx.update_serial(x, block_size=block_size)
-#     if verbose:
-#         print("Computation Ended!!! **********************************************************")
-#         sys.stdout.flush()
-#     return covdcovmtx
-#
-#
-# def compute_cov_dcov_matrix_mixed(params, verbose=False):
-#     print("PMixed")
-#     if verbose:
-#         print("Computation Began!!! **********************************************************")
-#         sys.stdout.flush()
-#     x, block_size = params
-#     bs = block_size
-#     covdcovmtx = CovDCovMatrix()
-#     covdcovmtx.update_clustered_homogeneous_block_sizes(x[0:bs], block_size=block_size, weight=0.5)
-#     covdcovmtx.update_clustered_homogeneous_block_sizes(x[bs:-bs], block_size=block_size, weight=1.0)
-#     covdcovmtx.update_clustered_homogeneous_block_sizes(x[-bs:], block_size=block_size, weight=0.5)
-#     covdcovmtx.update_serial(x, block_size=block_size)
-#     if verbose:
-#         print("Computation Ended!!! **********************************************************")
-#         sys.stdout.flush()
-#     return covdcovmtx
-
-
 class iGSFANode(mdp.Node):
     """This node implements "information-preserving graph-based SFA (iGSFA)", which is the main component of
     hierarchical iGSFA (HiGSFA).
@@ -1771,19 +1714,6 @@ class iGSFANode(mdp.Node):
             print("Data_std(x_zm)=", x_zm.var(axis=0))
             print("Data_std(x_app)=", x_app.var(axis=0))
             print("Data_std(sfa_removed_x)=", sfa_removed_x.var(axis=0))
-            print("x_app.mean(axis=0)=", x_app)
-            print("x[0]=", x[0])
-            print("x_zm[0]=", x_zm[0])
-            print("sfa_removed_x[0]=", sfa_removed_x[0])
-            print("pca_x[0]=", pca_x[0])
-            print("num_sfa_features_preserved=", self.num_sfa_features_preserved)
-            print("pca_node.output_dim=", self.pca_node.output_dim)
-            print("sfa_node.d=", self.sfa_node.d)
-            print("dtype(y)=", y.dtype)
-            print("dtype(x)=", x.dtype)
-            print("dtypes of x_zm, self.x_mean, x_app, sfa_removed_x, n_sfa_x, pca_x, sfa_pca_x_full",
-                  x_zm.dtype, self.x_mean.dtype, x_app.dtype, sfa_removed_x.dtype,
-                  n_sfa_x.dtype, pca_x.dtype, sfa_pca_x_full.dtype)
         return x
 
 
@@ -1798,16 +1728,10 @@ def SFANode_reduce_output_dim(sfa_node, new_output_dim, verbose=False):
         er = "Can only reduce output dimensionality of SFA node, not increase it (%d > %d)" % \
              (new_output_dim, sfa_node.output_dim)
         raise ValueError(er)
-    if verbose:
-        print("Before: sfa_node.d.shape=", sfa_node.d.shape, " sfa_node.sf.shape=", sfa_node.sf.shape)
-        print("sfa_node._bias.shape=", sfa_node._bias.shape)
     sfa_node.d = sfa_node.d[:new_output_dim]
     sfa_node.sf = sfa_node.sf[:, :new_output_dim]
     sfa_node._bias = sfa_node._bias[:new_output_dim]
     sfa_node._output_dim = new_output_dim
-    if verbose:
-        print("After: sfa_node.d.shape=", sfa_node.d.shape, " sfa_node.sf.shape=", sfa_node.sf.shape)
-        print(" sfa_node._bias.shape=", sfa_node._bias.shape)
 
 
 def PCANode_reduce_output_dim(pca_node, new_output_dim, verbose=False):
@@ -1820,9 +1744,6 @@ def PCANode_reduce_output_dim(pca_node, new_output_dim, verbose=False):
     if new_output_dim > pca_node.output_dim:
         er = "Can only reduce output dimensionality of PCA node, not increase it"
         raise ValueError(er)
-    if verbose:
-        print("Before: pca_node.d.shape=", pca_node.d.shape, " pca_node.v.shape=", pca_node.v.shape)
-        print(" pca_node.avg.shape=", pca_node.avg.shape)
 
     # if new_output_dim > 0:
     original_total_variance = pca_node.d.sum()
@@ -1832,11 +1753,6 @@ def PCANode_reduce_output_dim(pca_node, new_output_dim, verbose=False):
     # pca_node.avg is not affected by this method!
     pca_node._output_dim = new_output_dim
     pca_node.explained_variance = original_explained_variance * pca_node.d.sum() / original_total_variance
-    # else:
-
-    if verbose:
-        print("After: pca_node.d.shape=", pca_node.d.shape, " pca_node.v.shape=", pca_node.v.shape)
-        print(" pca_node.avg.shape=", pca_node.avg.shape)
 
 
 # Computes output errors dimension by dimension for a single sample: y - node.execute(x_app)
@@ -1918,20 +1834,20 @@ def example_pathological_outputs(experiment):
     # experiment = 0 #Select the experiment to perform, from 0 to 11
     print("experiment", experiment)
     if experiment == 0:
-        exp_title = "Original linear SFA graph"
+        exp_title = "Original linear SFA graph. Experiment 0"
     elif experiment == 1:
         v[0] = 10.0
         v[10] = 0.1
         v[19] = 10.0
-        exp_title = "Modified node weights 1"
+        exp_title = "Modified node weights. Experiment 1"
     elif experiment == 2:
         v[0] = 10.0
         v[19] = 0.1
-        exp_title = "Modified node weights 2"
+        exp_title = "Modified node weights. Experiment 2"
     elif experiment == 3:
         e[(0, 1)] = 0.1
         e[(18, 19)] = 10.0
-        exp_title = "Modified edge weights 3"
+        exp_title = "Modified edge weights. Experiment 3"
     elif experiment == 4:
         e[(0, 1)] = 0.01
         e[(18, 19)] = 0.01
@@ -1943,7 +1859,7 @@ def example_pathological_outputs(experiment):
         e[(5, 7)] = 0.5
 
         # e[(1,2)] = 0.1
-        exp_title = "Modified edge weights 4"
+        exp_title = "Modified edge weights. Experiment 4"
     elif experiment == 5:
         e[(10, 11)] = 0.02
         e[(1, 2)] = 0.02
@@ -1952,36 +1868,36 @@ def example_pathological_outputs(experiment):
         e[(17, 19)] = 1.0
         e[(14, 16)] = 1.0
 
-        exp_title = "Modified edge weights 5"
+        exp_title = "Modified edge weights. Experiment 5"
     elif experiment == 6:
         e[(6, 7)] = 0.1
         e[(5, 6)] = 0.1
-        exp_title = "Modified edge weights 6"
+        exp_title = "Modified edge weights. Experiment 6"
     elif experiment == 7:
         e = {}
         for j1 in range(19):
             for j2 in range(j1 + 1, 20):
                 e[(j1, j2)] = 1 / (l[j2] - l[j1] + 0.00005)
-        exp_title = "Modified edge weights for labels as w12 = 1/(l2-l1+0.00005) 7"
+        exp_title = "Modified edge weights for labels as w12 = 1/(l2-l1+0.00005). Experiment 7"
     elif experiment == 8:
         e = {}
         for j1 in range(19):
             for j2 in range(j1 + 1, 20):
                 e[(j1, j2)] = numx.exp(-0.25 * (l[j2] - l[j1]) ** 2)
-        exp_title = "Modified edge weights for labels as w12 = exp(-0.25*(l2-l1)**2) 8"
+        exp_title = "Modified edge weights for labels as w12 = exp(-0.25*(l2-l1)**2). Experiment 8"
     elif experiment == 9:
         e = {}
         for j1 in range(19):
             for j2 in range(j1 + 1, 20):
-                if l[j2] - l[j1] < 0.6:
-                    e[(j1, j2)] = 1 / (l[j2] - l[j1] + 0.00005)
-        exp_title = "Modified edge weights w12 = 1/(l2-l1+0.00005), for l2-l1<0.6 9"
+                if l[j2] - l[j1] < 1.5:
+                    e[(j1, j2)] = 1 / (l[j2] - l[j1] + 0.0005)
+        exp_title = "Modified edge weights w12 = 1/(l2-l1+0.0005), for l2-l1<1.5. Experiment 9"
     elif experiment == 10:
-        exp_title = "Mirroring training graph, w=%d" % half_width + "10"
+        exp_title = "Mirroring training graph, w=%d" % half_width + ". Experiment 10"
         train_mode = "smirror_window%d" % half_width
         e = {}
     elif experiment == 11:
-        exp_title = "Node weight adjustment training graph, w=%d " % half_width + "11"
+        exp_title = "Node weight adjustment training graph, w=%d " % half_width + ". Experiment 11"
         train_mode = "window%d" % half_width
         e = {}
     else:
@@ -2040,7 +1956,7 @@ def example_continuous_edge_weights():
     for n1 in range(20):
         for n2 in range(20):
             if n1 != n2:
-                e[(n1, n2)] = 1.0 / (numx.abs(l[n2] - l[n1]) + k)
+                e[(n1, n2)] = 1.0 / (numx.absolute(l[n2] - l[n1]) + k)
 
     exp_title = "Original linear SFA graph"
     n = GSFANode(output_dim=5)
@@ -2092,8 +2008,11 @@ def example_iGSFA():
     x_test[:, 1] += 1.0 * numx.arange(num_samples) / num_samples
     x_test[:, 2] += 0.5 * numx.arange(num_samples) / num_samples
 
-    import cuicuilco.patch_mdp
-    from cuicuilco.sfa_libs import zero_mean_unit_var
+    def zero_mean_unit_var(x):
+        x -= x.mean(axis=0)
+        x /= x.std(axis=0)
+    return x
+
     print("Node creation and training")
     n = iGSFANode(output_dim=15, reconstruct_with_sfa=False, slow_feature_scaling_method="data_dependent",
                   verbose=verbose)

--- a/mdp/nodes/gsfa_nodes.py
+++ b/mdp/nodes/gsfa_nodes.py
@@ -1150,7 +1150,7 @@ class CovDCovMatrix(object):
                   ((numx.diagonal(sum_prod_diffs) / num_diffs).mean()) ** 0.5)
 
     def update_compact_classes(self, x, block_sizes=None, Jdes=None):
-        num_samples, dim = x.shape
+        num_samples = x.shape[0]
 
         if self.verbose:
             print("block_sizes=", block_sizes, type(block_sizes))
@@ -1303,7 +1303,6 @@ class iGSFANode(mdp.Node):
     slowness principle", e-print arXiv:1601.03945,
     http://arxiv.org/abs/1601.03945, 2017.
     """
-
     def __init__(self, pre_expansion_node_class=None,
                  pre_expansion_out_dim=None, expansion_funcs=None,
                  expansion_output_dim=None, expansion_starting_point=None,
@@ -1312,7 +1311,6 @@ class iGSFANode(mdp.Node):
                  verbose=False, input_dim=None, output_dim=None,
                  dtype=None, **argv):
         """ Initializes the iGSFA node.
-
         pre_expansion_node_class: a node class. An instance of this class is
             used to filter the data before the expansion.
         pre_expansion_out_dim: the output dimensionality of the
@@ -1330,7 +1328,7 @@ class iGSFANode(mdp.Node):
             "data_dependent", and "QR_decomposition".
         delta_threshold: this parameter has two different meanings depending
             on its type. If it is real valued (e.g., 1.99), it determines the
-            parameter \Delta_threshold, which is used to decide how many slow
+            parameter Delta_threshold, which is used to decide how many slow
             features are preserved, depending on their delta values. If it is
             integer (e.g., 20), it directly specifies the exact size of the
             slow part.
@@ -1395,9 +1393,17 @@ class iGSFANode(mdp.Node):
 
         # The following variables are for internal use only (available after
         # training on a single batch only)
+        self.magn_n_sfa_x = None
+        self.num_sfa_features_preserved = None
         self.x_mean = None
         self.sfa_x_mean = None
         self.sfa_x_std = None
+        self.evar = None
+        # The following variables are for internal use only, by the QR slow
+        # feature scaling method
+        self.Q = None
+        self.R = None
+        self.Rpinv = None
 
     @staticmethod
     def is_trainable():
@@ -1601,7 +1607,6 @@ class iGSFANode(mdp.Node):
         PCANode_reduce_output_dim(self.pca_node, pca_output_dim,
                                   verbose=False)
 
-        # TODO:check that pca_out_dim > 0
         if verbose:
             print("executing PCA...")
 

--- a/mdp/nodes/gsfa_nodes.py
+++ b/mdp/nodes/gsfa_nodes.py
@@ -1,15 +1,17 @@
-######################################################################################################################
-# gsfa_nodes: This module implements the Graph-Based SFA Node (GSFANode) and the Information-Preserving GSFA Node    #
-#             (iGSFANode).                                                                                           #
-#                                                                                                                    #
-# See the following publications for details on GSFA and iGSFA:                                                      #
-# * Escalante-B A.-N., Wiskott L, "How to solve classification and regression problems on high-dimensional data with #
-# a supervised extension of Slow Feature Analysis". Journal of Machine Learning Research 14:3683-3719, 2013          #
-# * Escalante-B., A.-N. and Wiskott, L., "Improved graph-based {SFA}: Information preservation complements the       #
-# slowness principle", e-print arXiv:1601.03945, http://arxiv.org/abs/1601.03945, 2017                               #
-#                                                                                                                    #
-# Examples of using GSFA and iGSFA are provided at the end of the file                                               #
-######################################################################################################################
+###############################################################################
+# gsfa_nodes: This module implements the Graph-Based SFA Node (GSFANode) and  #
+# the Information-Preserving GSFA Node (iGSFANode).                           #
+#                                                                             #
+# See the following publications for details on GSFA and iGSFA:               #
+# * Escalante-B A.-N., Wiskott L, "How to solve classification and regression #
+# problems on high-dimensional data with a supervised extension of Slow       #
+# Feature Analysis". Journal of Machine Learning Research 14:3683-3719, 2013  #
+# * Escalante-B., A.-N. and Wiskott, L., "Improved graph-based {SFA}:         #
+# Information preservation complements the slowness principle", e-print       #
+# arXiv:1601.03945, http://arxiv.org/abs/1601.03945, 2017                     #
+#                                                                             #
+# Examples of using GSFA and iGSFA are provided at the end of the file        #
+###############################################################################
 
 from __future__ import absolute_import
 from __future__ import print_function
@@ -21,27 +23,32 @@ import sys
 
 import mdp
 from mdp import numx, NodeException, TrainingException
-from mdp.utils import (mult, symeig, pinv, CovarianceMatrix, SymeigException)
+from mdp.utils import (mult, symeig, pinv, SymeigException)
 from mdp.nodes import GeneralExpansionNode
 
 # For Python 2 & 3 compatibility
 try:
-  basestring
+    basestring
 except NameError:
-  basestring = str
+    basestring = str
+
 
 class GSFANode(mdp.Node):
-    """ This node implements "Graph-Based SFA (GSFA)", which is the main component of hierarchical GSFA (HGSFA).
+    """ This node implements "Graph-Based SFA (GSFA)", which is the main
+    component of hierarchical GSFA (HGSFA).
 
-    For further information, see: Escalante-B A.-N., Wiskott L, "How to solve classification and regression
-    problems on high-dimensional data with a supervised extension of Slow Feature Analysis". Journal of Machine
+    For further information, see: Escalante-B A.-N., Wiskott L, "How to solve
+    classification and regression problems on high-dimensional data with a
+    supervised extension of Slow Feature Analysis". Journal of Machine
     Learning Research 14:3683-3719, 2013
     """
-    def __init__(self, input_dim=None, output_dim=None, dtype=None, block_size=None, train_mode=None, verbose=False):
+    def __init__(self, input_dim=None, output_dim=None, dtype=None,
+                 block_size=None, train_mode=None, verbose=False):
         """Initializes the GSFA node, which is a subclass of the SFA node.
 
-        The parameters block_size and train_mode are not necessary and it is recommended to skip them here and
-        provide them as parameters to the train method.
+        The parameters block_size and train_mode are not necessary and it is
+        recommended to skip them here and provide them as parameters to the
+        train method.
         See the _train method for details.
         """
         super(GSFANode, self).__init__(input_dim, output_dim, dtype)
@@ -51,45 +58,51 @@ class GSFANode(mdp.Node):
         self.verbose = verbose
         self._symeig = symeig
         self._covdcovmtx = CovDCovMatrix()
-        # List of parameters that are accepted by train()
-        # self.list_train_params = ["train_mode", "block_size", "node_weights", "edge_weights", "verbose"]
 
-
-    def _train(self, x, block_size=None, train_mode=None, node_weights=None, edge_weights=None,
-                                 verbose=None):
+    def _train(self, x, block_size=None, train_mode=None, node_weights=None,
+               edge_weights=None, verbose=None):
         """ This is the main training function of GSFA.
         
         x: training data (each sample is a row)
 
-        The semantics of the remaining parameters depends on the training mode (train_mode) parameter
-        in order to train as in standard SFA:
-            set train_mode="regular" (the scale of the features should be corrected afterwards)
+        The semantics of the remaining parameters depends on the training mode
+        (train_mode) parameter in order to train as in standard SFA:
+            set train_mode="regular" (the scale of the features should be
+            corrected afterwards)
         in order to train using the clustered graph:
-            set train_mode="clustered". The cluster size is given by block_size (integer). Variable cluster sizes are 
-            possible if block_size is a list of integers. Samples belonging to the same class should be adjacent.
+            set train_mode="clustered". The cluster size is given by block_size
+            (integer). Variable cluster sizes are possible if block_size is a
+            list of integers. Samples belonging to the same class should be
+            adjacent.
         in order to train for classification:
-            set train_mode=("classification", labels, weight), where labels is an array with the class information and
-            weight is a scalar value (e.g., 1.0).
+            set train_mode=("classification", labels, weight), where labels is
+             an array with the class information and weight is a scalar value
+             (e.g., 1.0).
         in order to train for regression:
-            set train_mode=("serial_regression#", labels, weight), where # is an integer that specifies the block size
-            used by a serial graph, labels is an array with the label information and weight is a scalar value.
+            set train_mode=("serial_regression#", labels, weight), where # is
+            an integer that specifies the block size used by a serial graph,
+            labels is an array with the label information and weight is a
+            scalar value.
         in order to train using a graph without edges:
             set train_mode="unlabeled".
         in order to train using the serial graph:
-            set train_mode="serial", and use block_size (integer) to specify the group size. 
+            set train_mode="serial", and use block_size (integer) to specify
+            the group size.
         in order to train using the mixed graph:
-            set train_mode="mixed", and use block_size (integer) to specify the group size.           
+            set train_mode="mixed", and use block_size (integer) to specify
+            the group size.
         in order to train using an arbitrary user-provided graph:
-            set train_mode="graph", specify the node_weights (numpy 1D array), and the
-            edge_weights (numpy 2D array).
+            set train_mode="graph", specify the node_weights (numpy 1D array),
+            and the edge_weights (numpy 2D array).
         """
         if train_mode is None:
             train_mode = self.train_mode
         if verbose is None:
-           verbose = self.verbose
+            verbose = self.verbose
         if block_size is None:
             if verbose:
-                print("parameter block_size was not provided, using default value self.block_size")
+                print("parameter block_size was not provided ",
+                      "using default value self.block_size")
             block_size = self.block_size
 
         self.set_input_dim(x.shape[1])
@@ -119,14 +132,18 @@ class GSFANode(mdp.Node):
                     block_sizes = []
                     for label in unique_labels:
                         block_sizes.append((labels == label).sum())
-                    self._covdcovmtx.update_clustered(x2, block_sizes=block_sizes, weight=weight)
+                    self._covdcovmtx.update_clustered(x2,
+                                                      block_sizes=block_sizes,
+                                                      weight=weight)
                 elif method.startswith("serial_regression"):
                     block_size = int(method[len("serial_regression"):])
                     if verbose:
-                        print("update serial_regression, block_size=", block_size)
+                        print("update serial_regression, block_size=",
+                              block_size)
                     ordering = numx.argsort(labels)
                     x2 = x[ordering, :]
-                    self._covdcovmtx.update_serial(x2, block_size=block_size, weight=weight)
+                    self._covdcovmtx.update_serial(x2, block_size=block_size,
+                                                   weight=weight)
                 else:
                     er = "method unknown: %s" % (str(method))
                     raise ValueError(er)
@@ -134,7 +151,7 @@ class GSFANode(mdp.Node):
                 if train_mode == 'unlabeled':
                     if verbose:
                         print("update_unlabeled")
-                    self._covdcovmtx.update_unlabeled(x, weight=0.00015)  # Warning, set this weight appropriately!
+                    self._covdcovmtx.update_unlabeled(x, weight=1.0)
                 elif train_mode == "regular":
                     if verbose:
                         print("update_regular")
@@ -142,12 +159,15 @@ class GSFANode(mdp.Node):
                 elif train_mode == 'clustered':
                     if verbose:
                         print("update_clustered")
-                    self._covdcovmtx.update_clustered(x, block_sizes=block_size, weight=1.0)
+                    self._covdcovmtx.update_clustered(x,
+                                                      block_sizes=block_size,
+                                                      weight=1.0)
                 elif train_mode.startswith('compact_classes'):
                     if verbose:
                         print("update_compact_classes:", train_mode)
                     J = int(train_mode[len('compact_classes'):])
-                    self._covdcovmtx.update_compact_classes(x, block_sizes=block_size, Jdes=J, weight=1.0)
+                    self._covdcovmtx.update_compact_classes(
+                        x, block_sizes=block_size, Jdes=J)
                 elif train_mode == 'serial':
                     if verbose:
                         print("update_serial")
@@ -165,48 +185,60 @@ class GSFANode(mdp.Node):
                     x2 = numx.zeros_like(x)
                     for i in range(num_blocks):
                         for j in range(dual_num_blocks):
-                            x2[j * dual_block_size + i * chunk_size:j * dual_block_size + (i + 1) * chunk_size] = \
-                                x[i * block_size + j * chunk_size:i * block_size + (j + 1) * chunk_size]
-                    self._covdcovmtx.update_serial(x2, block_size=dual_block_size, weight=0.0)
+                            x2[j * dual_block_size + i * chunk_size:
+                                j * dual_block_size + (i + 1) * chunk_size] = \
+                                x[i * block_size + j * chunk_size:
+                                i * block_size + (j + 1) * chunk_size]
+                    self._covdcovmtx.update_serial(x2,
+                                                   block_size=dual_block_size,
+                                                   weight=0.0)
                 elif train_mode == 'mixed':
                     if verbose:
                         print("update mixed")
                     bs = block_size
-                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x[0:bs], weight=2.0,
-                                                                              block_size=block_size)
-                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x[bs:-bs], weight=1.0,
-                                                                              block_size=block_size)
-                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x[-bs:], weight=2.0,
-                                                                              block_size=block_size)
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(
+                        x[0:bs], weight=2.0, block_size=block_size)
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(
+                        x[bs:-bs], weight=1.0, block_size=block_size)
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(
+                        x[-bs:], weight=2.0, block_size=block_size)
                     self._covdcovmtx.update_serial(x, block_size=block_size)
                 elif train_mode[0:6] == 'window':
                     window_halfwidth = int(train_mode[6:])
                     if verbose:
                         print("Window (%d)" % window_halfwidth)
-                    self._covdcovmtx.update_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                    self._covdcovmtx.update_sliding_window(
+                        x, weight=1.0, window_halfwidth=window_halfwidth)
                 elif train_mode[0:7] == 'fwindow':
                     window_halfwidth = int(train_mode[7:])
                     if verbose:
                         print("Fast Window (%d)" % window_halfwidth)
-                    self._covdcovmtx.update_fast_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                    self._covdcovmtx.update_fast_sliding_window(
+                        x, weight=1.0, window_halfwidth=window_halfwidth)
                 elif train_mode[0:13] == 'mirror_window':
                     window_halfwidth = int(train_mode[13:])
                     if verbose:
                         print("Mirroring Window (%d)" % window_halfwidth)
-                    self._covdcovmtx.update_mirroring_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                    self._covdcovmtx.update_mirroring_sliding_window(
+                        x, weight=1.0, window_halfwidth=window_halfwidth)
                 elif train_mode[0:14] == 'smirror_window':
                     window_halfwidth = int(train_mode[14:])
                     if verbose:
                         print("Slow Mirroring Window (%d)" % window_halfwidth)
-                    self._covdcovmtx.update_slow_mirroring_sliding_window(x, weight=1.0, window_halfwidth=window_halfwidth)
+                    self._covdcovmtx.update_slow_mirroring_sliding_window(
+                        x, weight=1.0, window_halfwidth=window_halfwidth)
                 elif train_mode == 'graph':
                     if verbose:
                         print("update_graph")
-                    self._covdcovmtx.update_graph(x, node_weights=node_weights, edge_weights=edge_weights, weight=1.0)
+                    self._covdcovmtx.update_graph(
+                        x, node_weights=node_weights,
+                        edge_weights=edge_weights, weight=1.0)
                 elif train_mode == 'graph_old':
                     if verbose:
                         print("update_graph_old")
-                    self._covdcovmtx.update_graph_old(x, node_weights=node_weights, edge_weights=edge_weights, weight=1.0)
+                    self._covdcovmtx.update_graph_old(
+                        x, node_weights=node_weights,
+                        edge_weights=edge_weights, weight=1.0)
                 elif train_mode == 'smart_unlabeled2':
                     if verbose:
                         print("smart_unlabeled2")
@@ -214,27 +246,31 @@ class GSFANode(mdp.Node):
 
                     N1 = Q1 = self._covdcovmtx.num_samples * 1.0
                     R1 = self._covdcovmtx.num_diffs * 1.0
-                    sum_x_labeled_2D = self._covdcovmtx.sum_x.reshape((1, -1)) + 0.0
-                    sum_prod_x_labeled = self._covdcovmtx.sum_prod_x + 0.0
+                    sum_x_labeled_2D = self._covdcovmtx.sum_x.reshape((1, -1))
+                    sum_prod_x_labeled = self._covdcovmtx.sum_prod_x
                     if verbose:
-                        print("Original sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+                        print("Original sum_x[0]/num_samples=",
+                              self._covdcovmtx.sum_x[0] /
+                              self._covdcovmtx.num_samples)
 
-                    weight_fraction_unlabeled = 0.2  # 0.1, 0.25
-                    additional_weight_unlabeled = -0.025  # 0.02 0.25, 0.65?
+                    weight_fraction_unlabeled = 0.2
+                    additional_weight_unlabeled = -0.025
 
                     w1 = Q1 * 1.0 / R1 * (1.0 - weight_fraction_unlabeled)
                     if verbose:
-                        print("weight_fraction_unlabeled=", weight_fraction_unlabeled)
+                        print("weight_fraction_unlabeled=",
+                              weight_fraction_unlabeled)
                         print("N1=Q1=", Q1, "R1=", R1, "w1=", w1)
                         print("")
 
                     self._covdcovmtx.sum_prod_diffs *= w1
                     self._covdcovmtx.num_diffs *= w1
                     if verbose:
-                        print("After diff scaling: num_samples=", self._covdcovmtx.num_samples)
+                        print("After diff scaling: num_samples=",
+                              self._covdcovmtx.num_samples)
                         print("num_diffs=", self._covdcovmtx.num_diffs, "\n")
 
-                    node_weights2 = Q1 * weight_fraction_unlabeled / N2  # w2*N1
+                    node_weights2 = Q1 * weight_fraction_unlabeled / N2
                     w12 = node_weights2 / N1  # One directional weights
                     if verbose:
                         print("w12 (one dir)", w12)
@@ -242,35 +278,52 @@ class GSFANode(mdp.Node):
                     sum_x_unlabeled_2D = x.sum(axis=0).reshape((1, -1))
                     sum_prod_x_unlabeled = mdp.utils.mult(x.T, x)
 
-                    self._covdcovmtx.add_samples(sum_prod_x_unlabeled, sum_x_unlabeled_2D.flatten(), num_samples=N2,
-                                                weight=node_weights2)
+                    self._covdcovmtx.add_samples(sum_prod_x_unlabeled,
+                                                 sum_x_unlabeled_2D.flatten(),
+                                                 num_samples=N2,
+                                                 weight=node_weights2)
                     if verbose:
-                        print("After adding unlabeled nodes: num_samples=", self._covdcovmtx.num_samples)
+                        print("After adding unlabeled nodes: num_samples=",
+                              self._covdcovmtx.num_samples)
                         print("num_diffs=", self._covdcovmtx.num_diffs)
-                        print("sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+                        print("sum_x[0]/num_samples=",
+                              self._covdcovmtx.sum_x[0] /
+                              self._covdcovmtx.num_samples)
                         print("")
 
                         print("N2=", N2, "node_weights2=", node_weights2)
 
                     additional_diffs = sum_prod_x_unlabeled * N1 - \
-                                       mdp.utils.mult(sum_x_labeled_2D.T, sum_x_unlabeled_2D) - \
-                                       mdp.utils.mult(sum_x_unlabeled_2D.T, sum_x_labeled_2D) + sum_prod_x_labeled * N2
+                                       mdp.utils.mult(sum_x_labeled_2D.T,
+                                                      sum_x_unlabeled_2D) - \
+                                       mdp.utils.mult(sum_x_unlabeled_2D.T,
+                                                      sum_x_labeled_2D) + \
+                                       sum_prod_x_labeled * N2
                     if verbose:
-                        print("w12=", w12, "additional_diffs=", additional_diffs)
-                    self._covdcovmtx.add_diffs(2 * additional_diffs, 2 * N1 * N2,
-                                              weight=w12)  # to account for both directions
+                        print("w12=", w12, "additional_diffs=",
+                              additional_diffs)
+                    # accounts for both directions
+                    self._covdcovmtx.add_diffs(2 * additional_diffs,
+                                               2 * N1 * N2,
+                                               weight=w12)
                     if verbose:
-                        print("After mixed diff addition: num_samples=", self._covdcovmtx.num_samples)
+                        print("After mixed diff addition: num_samples=",
+                              self._covdcovmtx.num_samples)
                         print("num_diffs=", self._covdcovmtx.num_diffs)
-                        print("sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+                        print("sum_x[0]/num_samples=",
+                              self._covdcovmtx.sum_x[0] / \
+                              self._covdcovmtx.num_samples)
 
                         print("\n Adding complete graph for unlabeled data")
-                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x, weight=additional_weight_unlabeled,
-                                                                              block_size=N2)
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(
+                        x, weight=additional_weight_unlabeled, block_size=N2)
                     if verbose:
-                        print("After complete x2 addition: num_samples=", self._covdcovmtx.num_samples)
+                        print("After complete x2 addition: num_samples=",
+                              self._covdcovmtx.num_samples)
                         print("num_diffs=", self._covdcovmtx.num_diffs)
-                        print("sum_x[0]/num_samples=", self._covdcovmtx.sum_x[0] / self._covdcovmtx.num_samples)
+                        print("sum_x[0]/num_samples=",
+                              self._covdcovmtx.sum_x[0] /
+                              self._covdcovmtx.num_samples)
 
                 elif train_mode == 'smart_unlabeled3':
                     if verbose:
@@ -282,24 +335,28 @@ class GSFANode(mdp.Node):
                     if verbose:
                         print("N1=Q1=", Q1, "R1=", R1, "N2=", N2)
 
-                    v = 2.0 ** (-9.5)  # weight of unlabeled samples (making it "500" vs "500")
-                    C = 10.0  # Clustered graph assumed, with C classes, and each one having N1/C samples
+                    v = 2.0 ** (-9.5)  # weight of unlabeled samples
+                    C = 10.0  # Clustered graph assumed, with C classes,
+                    # and each class having N1/C samples
                     if verbose:
                         print("v=", v, "C=", C)
 
                     v_norm = v / C
                     N1_norm = N1 / C
 
-                    sum_x_labeled = self._covdcovmtx.sum_x.reshape((1, -1)) + 0.0
+                    sum_x_labeled = self._covdcovmtx.sum_x.reshape((1, -1))
                     sum_prod_x_labeled = self._covdcovmtx.sum_prod_x + 0.0
 
                     if verbose:
-                        print("Original (Diag(C')/num_diffs.avg)**0.5 =", ((numx.diagonal(
-                            self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+                        print("Original (Diag(C')/num_diffs.avg)**0.5 =",
+                              ((numx.diagonal(self._covdcovmtx.sum_prod_diffs)
+                                / self._covdcovmtx.num_diffs).mean()) ** 0.5)
 
-                    weight_adjustment = (N1_norm - 1) / (N1_norm - 1 + v_norm * N2)
+                    weight_adjustment = (N1_norm - 1) / \
+                                        (N1_norm - 1 + v_norm * N2)
                     if verbose:
-                        print("weight_adjustment =", weight_adjustment, "w11=", 1 / (N1_norm - 1 + v_norm * N2))
+                        print("weight_adjustment =", weight_adjustment,
+                              "w11=", 1 / (N1_norm - 1 + v_norm * N2))
 
                     self._covdcovmtx.sum_x *= weight_adjustment
                     self._covdcovmtx.sum_prod_x *= weight_adjustment
@@ -308,63 +365,87 @@ class GSFANode(mdp.Node):
                     self._covdcovmtx.num_diffs *= weight_adjustment
                     node_weights_complete_1 = weight_adjustment
                     if verbose:
-                        print("num_diffs (w11) after weight_adjustment=", self._covdcovmtx.num_diffs)
+                        print("num_diffs (w11) after weight_adjustment=",
+                              self._covdcovmtx.num_diffs)
                     w11 = 1 / (N1_norm - 1 + v_norm * N2)
                     if verbose:
-                        print("After adjustment (Diag(C')/num_diffs.avg)**0.5 =", ((numx.diagonal(
-                        self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+                        print("Adjusted (Diag(C')/num_diffs.avg)**0.5 =",
+                              ((numx.diagonal(self._covdcovmtx.sum_prod_diffs)
+                                / self._covdcovmtx.num_diffs).mean()) ** 0.5)
                         print("")
 
-                    # Connections within unlabeled data (notice that C times this is equivalent to
-                    # v*v/(N1+v*(N2-1)) once)
-                    w22 = 0.5 * 2 * v_norm * v_norm / (N1_norm + v_norm * (N2 - 1))
+                    # Connections within unlabeled data (notice that C times
+                    # this is equivalent to v*v/(N1+v*(N2-1)) once)
+                    w22 = 0.5 * 2 * v_norm * v_norm / (N1_norm +
+                                                       v_norm * (N2 - 1))
                     sum_x_unlabeled = x.sum(axis=0).reshape((1, -1))
                     sum_prod_x_unlabeled = mdp.utils.mult(x.T, x)
                     node_weights_complete_2 = w22 * (N2 - 1) * C
-                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(x, weight=node_weights_complete_2,
-                                                                              block_size=N2)
+                    self._covdcovmtx.update_clustered_homogeneous_block_sizes(
+                        x, weight=node_weights_complete_2, block_size=N2)
                     if verbose:
-                        print("w22=", w22, "node_weights_complete_2*N2=", node_weights_complete_2 * N2)
-                        print("After adding complete 2: num_samples=", self._covdcovmtx.num_samples)
+                        print("w22=", w22, "node_weights_complete_2*N2=",
+                              node_weights_complete_2 * N2)
+                        print("After adding complete 2: num_samples=",
+                              self._covdcovmtx.num_samples)
                         print("num_diffs=", self._covdcovmtx.num_diffs)
-                        print(" (Diag(C')/num_diffs.avg)**0.5 =", ((numx.diagonal(
-                            self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+                        print(" (Diag(C')/num_diffs.avg)**0.5 =",
+                              ((numx.diagonal(self._covdcovmtx.sum_prod_diffs)
+                                / self._covdcovmtx.num_diffs).mean()) ** 0.5)
                         print("")
 
                     # Connections between labeled and unlabeled samples
-                    w12 = 2 * 0.5 * v_norm * (1 / (N1_norm - 1 + v_norm * N2) + 1 / (
-                        N1_norm + v_norm * (N2 - 1)))  # Accounts for transitions in both directions
+                    # Accounts for transitions in both directions
+                    w12 = (2 * 0.5 * v_norm * (1 / (N1_norm - 1 + v_norm * N2)
+                                               + 1 / (N1_norm +
+                                                      v_norm * (N2 - 1))))
                     if verbose:
                         print("(twice) w12=", w12)
                     sum_prod_diffs_mixed = w12 * (N1 * sum_prod_x_unlabeled -
-                                                  (mdp.utils.mult(sum_x_labeled.T, sum_x_unlabeled) +
-                                                   mdp.utils.mult(sum_x_unlabeled.T, sum_x_labeled)) +
-                                                  N2 * sum_prod_x_labeled)
+                        (mdp.utils.mult(sum_x_labeled.T, sum_x_unlabeled) +
+                         mdp.utils.mult(sum_x_unlabeled.T, sum_x_labeled)) +
+                        N2 * sum_prod_x_labeled)
                     self._covdcovmtx.sum_prod_diffs += sum_prod_diffs_mixed
-                    self._covdcovmtx.num_diffs += C * N1_norm * N2 * w12  # w12 already counts twice
+                    # w12 is already counted twice
+                    self._covdcovmtx.num_diffs += C * N1_norm * N2 * w12
                     if verbose:
-                        print(" (Diag(mixed)/num_diffs.avg)**0.5 =", ((numx.diagonal(sum_prod_diffs_mixed) /
-                                                                   (C * N1_norm * N2 * w12)).mean()) ** 0.5, "\n")
+                        print(" (Diag(mixed)/num_diffs.avg)**0.5 =",
+                              ((numx.diagonal(sum_prod_diffs_mixed) /
+                                  (C * N1_norm * N2 * w12)).mean()) ** 0.5)
 
                     # Additional adjustment for node weights of unlabeled data
                     missing_weight_unlabeled = v - node_weights_complete_2
                     missing_weight_labeled = 1.0 - node_weights_complete_1
                     if verbose:
-                        print("missing_weight_unlabeled=", missing_weight_unlabeled)
-                        print("Before two final add_samples: num_samples=", self._covdcovmtx.num_samples)
+                        print("missing_weight_unlabeled=",
+                              missing_weight_unlabeled)
+                        print("Before two final add_samples: num_samples=",
+                              self._covdcovmtx.num_samples)
                         print("num_diffs=", self._covdcovmtx.num_diffs)
-                    self._covdcovmtx.add_samples(sum_prod_x_unlabeled, sum_x_unlabeled, N2, missing_weight_unlabeled)
-                    self._covdcovmtx.add_samples(sum_prod_x_labeled, sum_x_labeled, N1, missing_weight_labeled)
+                    self._covdcovmtx.add_samples(sum_prod_x_unlabeled,
+                                                 sum_x_unlabeled, N2,
+                                                 missing_weight_unlabeled)
+                    self._covdcovmtx.add_samples(sum_prod_x_labeled,
+                                                 sum_x_labeled, N1,
+                                                 missing_weight_labeled)
                     if verbose:
-                        print("Final transformation: num_samples=", self._covdcovmtx.num_samples)
+                        print("Final transformation: num_samples=",
+                              self._covdcovmtx.num_samples)
                         print("num_diffs=", self._covdcovmtx.num_diffs)
-                        print("Summary v11=%f+%f, v22=%f+%f" % (weight_adjustment, missing_weight_labeled,
-                                                            node_weights_complete_2, missing_weight_unlabeled))
-                        print("Summary w11=%f, w22=%f, w12(two ways)=%f" % (w11, w22, w12))
-                        print("Summary (N1/C-1)*w11=%f, N2*w12 (one way)=%f" % ((N1 / C - 1) * w11, N2 * w12 / 2))
-                        print("Summary (N2-1)*w22*C=%f, N1*w12 (one way)=%f" % ((N2 - 1) * w22 * C, N1 * w12 / 2))
-                        print("Summary (Diag(C')/num_diffs.avg)**0.5 =", ((numx.diagonal(
-                            self._covdcovmtx.sum_prod_diffs) / self._covdcovmtx.num_diffs).mean()) ** 0.5)
+                        print("v11=%f+%f, v22=%f+%f" %
+                              (weight_adjustment,
+                               missing_weight_labeled,
+                               node_weights_complete_2,
+                               missing_weight_unlabeled))
+                        print("w11=%f, w22=%f, w12(two ways)=%f" % (w11, w22,
+                                                                    w12))
+                        print("(N1/C-1)*w11=%f, N2*w12 (one way)=%f" %
+                              ((N1 / C - 1) * w11, N2 * w12 / 2))
+                        print("(N2-1)*w22*C=%f, N1*w12 (one way)=%f" %
+                              ((N2 - 1) * w22 * C, N1 * w12 / 2))
+                        print("(Diag(C')/num_diffs.avg)**0.5 =",
+                              ((numx.diagonal(self._covdcovmtx.sum_prod_diffs)
+                                / self._covdcovmtx.num_diffs).mean()) ** 0.5)
                 elif train_mode == 'ignore_data':
                     if verbose:
                         print("Training graph: ignoring data")
@@ -377,16 +458,18 @@ class GSFANode(mdp.Node):
 
     def _stop_training(self, debug=False, verbose=None):
         if verbose is None:
-           verbose = self.verbose
+            verbose = self.verbose
         if verbose:
             print("stop_training: self.block_size=", self.block_size)
-            print("self._covdcovmtx.num_samples = ", self._covdcovmtx.num_samples)
+            print("self._covdcovmtx.num_samples = ",
+                  self._covdcovmtx.num_samples)
             print("self._covdcovmtx.num_diffs= ", self._covdcovmtx.num_diffs)
         self.cov_mtx, self.avg, self.dcov_mtx = self._covdcovmtx.fix()
 
         if verbose:
             print("Finishing GSFA training: ", self._covdcovmtx.num_samples)
-            print(" num_samples, and ", self._covdcovmtx.num_diffs, " num_diffs")
+            print(" num_samples, and ", self._covdcovmtx.num_diffs,
+                  " num_diffs")
             print("DCov[0:3,0:3] is", self.dcov_mtx[0:3, 0:3])
 
         rng = self._set_range()
@@ -395,7 +478,8 @@ class GSFANode(mdp.Node):
         try:
             if verbose:
                 print("***Range used=", rng)
-            self.d, self.sf = self._symeig(self.dcov_mtx, self.cov_mtx, range=rng, overwrite=(not debug))
+            self.d, self.sf = self._symeig(self.dcov_mtx, self.cov_mtx,
+                                           range=rng, overwrite=(not debug))
             d = self.d
             # check that we get only non-negative eigenvalues
             if d.min() < 0:
@@ -424,14 +508,16 @@ class GSFANode(mdp.Node):
         return mult(x, sf) - bias
 
     def _inverse(self, y):
-        """ This function uses a pseudoinverse of the matrix sf to approximate an inverse to the transformation.
+        """ This function uses a pseudoinverse of the matrix sf to approximate
+         an inverse to the transformation.
         """
         if self.pinv is None:
             self.pinv = pinv(self.sf)
         return mult(y, self.pinv) + self.avg
 
     def _set_range(self):
-        if self.output_dim is not None and (self.output_dim <= self.input_dim or self.input_dim is None):
+        if self.output_dim is not None and (self.output_dim <= self.input_dim
+                                            or self.input_dim is None):
             # (eigenvalues sorted in ascending order)
             rng = (1, self.output_dim)
         else:
@@ -441,9 +527,9 @@ class GSFANode(mdp.Node):
         return rng
 
 
-##############################################################################################################
-#                              HELPER FUNCTIONS                                                              #
-##############################################################################################################
+###############################################################################
+#                              HELPER FUNCTIONS                               #
+###############################################################################
 
 def graph_delta_values(y, edge_weights):
     """ Computes delta values from an arbitrary graph as in the objective 
@@ -468,7 +554,8 @@ def comp_delta(x):
 
 
 def Hamming_weight(integer_list):
-    """ Computes the Hamming weight of an integer or a list of integers (number of bits equal to one) 
+    """ Computes the Hamming weight of an integer or a list of integers (number
+     of bits equal to one).
     """
     if isinstance(integer_list, list):
         return [Hamming_weight(k) for k in integer_list]
@@ -486,23 +573,28 @@ def Hamming_weight(integer_list):
 
 
 class CovDCovMatrix(object):
-    """Special purpose class to compute the covariance/second moment matrices used by GSFA.
-       It supports efficiently training methods for various graphs: e.g., clustered, serial, mixed.
-       Joint computation of these matrices is typically more efficient than their separate computation.
+    """Special purpose class to compute the covariance/second moment matrices
+    used by GSFA. It supports efficiently training methods for various graphs:
+    e.g., clustered, serial, mixed.
+    Joint computation of these matrices is typically more efficient than
+    their separate computation.
     """
     def __init__(self, verbose=False):
         """Variable descriptions:
             sum_x: a vector with the sum of all data samples
-            sum_prod_x: a matrix with sum of all samples multiplied by their transposes
+            sum_prod_x: a matrix with sum of all samples multiplied by their
+                transposes
             num_samples: the total weighted number of samples
-            sum_prod_diffs: a matrix with sum of all sample differences multiplied by their transposes
+            sum_prod_diffs: a matrix with sum of all sample differences
+                multiplied by their transposes
             num_diffs: the total weighted number of sample differences
             verbose: a Boolean verbosity parameter
 
         The following variables are available after fix() has been called.
             cov_mtx: the resulting covariance matrix of the samples
             avg: the average sample
-            dcov_mtx: the resulting second-moment matrix of the sample differences
+            dcov_mtx: the resulting second-moment matrix of the sample
+            differences
         """
         self.sum_x = None
         self.sum_prod_x = None
@@ -517,7 +609,8 @@ class CovDCovMatrix(object):
         self.dcov_mtx = None
 
     def add_samples(self, sum_prod_x, sum_x, num_samples, weight=1.0):
-        """ The given sample information (sum_prod_x, sum_x, num_samples) is added to the cumulative
+        """ The given sample information (sum_prod_x, sum_x, num_samples) is
+        added to the cumulative
         computation of the covariance matrix.
         """
         weighted_sum_x = sum_x * weight
@@ -534,8 +627,9 @@ class CovDCovMatrix(object):
         self.num_samples = self.num_samples + weighted_num_samples
 
     def add_diffs(self, sum_prod_diffs, num_diffs, weight=1.0):
-        """ The given sample differences information (sum_prod_diffs, num_diffs) is added to the cumulative
-        computation of the second-moment differences matrix.
+        """ The given sample differences information (sum_prod_diffs,
+        num_diffs) is added to the cumulative computation of the second-moment
+        differences matrix.
         """
         weighted_sum_prod_diffs = sum_prod_diffs * weight
         weighted_num_diffs = num_diffs * weight
@@ -548,7 +642,9 @@ class CovDCovMatrix(object):
         self.num_diffs = self.num_diffs + weighted_num_diffs
 
     def update_unlabeled(self, x, weight=1.0):
-        """ Add unlabeled samples to the covariance matrix (DCov remains unmodified) """
+        """ Add unlabeled samples to the covariance matrix
+        (DCov remains unmodified).
+        """
         num_samples, dim = x.shape
 
         sum_x = x.sum(axis=0)
@@ -556,7 +652,9 @@ class CovDCovMatrix(object):
         self.add_samples(sum_prod_x, sum_x, num_samples, weight)
 
     def update_regular(self, x, weight=1.0):
-        """This is equivalent to regular SFA training (except for the final feature scale). """
+        """This is equivalent to regular SFA training (except for the final
+        feature scale).
+        """
         num_samples, dim = x.shape
 
         # Update Cov Matrix
@@ -570,9 +668,11 @@ class CovDCovMatrix(object):
         sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
         self.add_diffs(sum_prod_diffs, num_diffs, weight)
 
-    def update_graph(self, x, node_weights=None, edge_weights=None, weight=1.0):
-        """Updates the covariance/second moment matrices using an user-provided graph specified by
-        (x, node weights, edge weights, and a global weight).
+    def update_graph(self, x, node_weights=None, edge_weights=None,
+                     weight=1.0):
+        """Updates the covariance/second moment matrices using an user-provided
+         graph specified by (x, node weights, edge weights, and a global
+         weight).
 
          Usually sum(node_weights) = num_samples.
          """
@@ -582,20 +682,24 @@ class CovDCovMatrix(object):
             node_weights = numx.ones(num_samples)
 
         if len(node_weights) != num_samples:
-            er = "Node weights should be the same length %d as the number of samples %d" % \
-                 (len(node_weights), num_samples)
+            er = "Node weights should have the same length " + \
+                 "%d as the number of samples %d" % (len(node_weights),
+                                                     num_samples)
             raise TrainingException(er)
 
         if edge_weights is None:
-            er = "edge_weights should be a dictionary with entries: d[(i,j)] = w_{i,j} or an NxN array"
+            er = "edge_weights should be a dictionary with entries: " + \
+                 "d[(i,j)] = w_{i,j} or an NxN array"
             raise TrainingException(er)
 
         if isinstance(edge_weights, numx.ndarray):
             # TODO: eventually make sure edge_weights are symmetric
             # TODO: eventually make sure consistency restriction is fulfilled
             if edge_weights.shape != (num_samples, num_samples):
-                er = "Error, dimensions of edge_weights should be (%d,%d) but is (%d,%d)" % \
-                     (num_samples, num_samples, edge_weights.shape[0], edge_weights.shape[1])
+                er = "Shape of edge_weights should be " + \
+                     "(%d, %d)" % (num_samples, num_samples) + \
+                     " but is (%d, %d)" % (edge_weights.shape[0],
+                                           edge_weights.shape[1])
                 raise TrainingException(er)
 
         node_weights_column = node_weights.reshape((num_samples, 1))
@@ -605,15 +709,18 @@ class CovDCovMatrix(object):
         weighted_sum_x = weighted_x.sum(axis=0)
         weighted_sum_prod_x = mdp.utils.mult(x.T, weighted_x)
         weighted_num_samples = node_weights.sum()
-        self.add_samples(weighted_sum_prod_x, weighted_sum_x, weighted_num_samples, weight=weight)
+        self.add_samples(weighted_sum_prod_x, weighted_sum_x,
+                         weighted_num_samples, weight=weight)
 
         # Update DCov Matrix
         if isinstance(edge_weights, numx.ndarray):
             weighted_num_diffs = edge_weights.sum()  # normalization constant R
-            prod1 = weighted_sum_prod_x  # TODO: eventually check these equations, they might only work if Q==R
+            prod1 = weighted_sum_prod_x  # TODO: eventually check these
+            # equations, they might only work if Q==R
             prod2 = mdp.utils.mult(mdp.utils.mult(x.T, edge_weights), x)
             weighted_sum_prod_diffs = 2 * prod1 - 2 * prod2
-            self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs, weight=weight)
+            self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs,
+                           weight=weight)
         else:
             num_diffs = len(edge_weights)
             diffs = numx.zeros((num_diffs, dim))
@@ -628,11 +735,14 @@ class CovDCovMatrix(object):
                 weighted_num_diffs += w_ij
 
             weighted_sum_prod_diffs = mdp.utils.mult(diffs.T, weighted_diffs)
-            self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs, weight=weight)
+            self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs,
+                           weight=weight)
 
-    def update_graph_old(self, x, node_weights=None, edge_weights=None, weight=1.0):
-        """This method performs the same task as update_graph. It is slower than update_graph because it
-        has not been optimized. Thus, it is mainly useful to verify the correctness of update_graph.
+    def update_graph_old(self, x, node_weights=None, edge_weights=None,
+                         weight=1.0):
+        """This method performs the same task as update_graph. It is slower
+        than update_graph because it has not been optimized. Thus, it is
+        mainly useful to verify the correctness of update_graph.
         """
         num_samples, dim = x.shape
 
@@ -640,12 +750,14 @@ class CovDCovMatrix(object):
             node_weights = numx.ones(num_samples)
 
         if len(node_weights) != num_samples:
-            er = "Node weights should be the same length %d as the number of samples %d" % \
-                 (len(node_weights), num_samples)
+            er = "Node weights should be the same length " + \
+                 "%d as the number of samples %d" % (len(node_weights),
+                                                     num_samples)
             raise TrainingException(er)
 
         if edge_weights is None:
-            er = "edge_weights should be a dictionary with entries: d[(i,j)] = w_{i,j} or an NxN array"
+            er = "edge_weights should be a dictionary with entries: " + \
+                 "d[(i,j)] = w_{i,j} or an NxN array"
             raise TrainingException(er)
 
         if isinstance(edge_weights, numx.ndarray):
@@ -657,8 +769,9 @@ class CovDCovMatrix(object):
                             e_w[(i, j)] = edge_weights[i, j]
                 edge_weights = e_w
             else:
-                er = "Error, dimensions of edge_weights should be (%d,%d) but is (%d,%d)" % \
-                     (num_samples, num_samples, edge_weights.shape[0], edge_weights.shape[1])
+                er = "edge_weights.shape should be (%d,%d) but is (%d,%d)" % \
+                     (num_samples, num_samples, edge_weights.shape[0],
+                      edge_weights.shape[1])
                 raise TrainingException(er)
         node_weights_column = node_weights.reshape((num_samples, 1))
         # Update Cov Matrix
@@ -667,7 +780,8 @@ class CovDCovMatrix(object):
         weighted_sum_x = weighted_x.sum(axis=0)
         weighted_sum_prod_x = mdp.utils.mult(x.T, weighted_x)
         weighted_num_samples = node_weights.sum()
-        self.add_samples(weighted_sum_prod_x, weighted_sum_x, weighted_num_samples, weight=weight)
+        self.add_samples(weighted_sum_prod_x, weighted_sum_x,
+                         weighted_num_samples, weight=weight)
 
         # Update DCov Matrix
         num_diffs = len(edge_weights)
@@ -683,14 +797,20 @@ class CovDCovMatrix(object):
             weighted_num_diffs += w_ij
 
         weighted_sum_prod_diffs = mdp.utils.mult(diffs.T, weighted_diffs)
-        self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs, weight=weight)
+        self.add_diffs(weighted_sum_prod_diffs, weighted_num_diffs,
+                       weight=weight)
 
-    def update_mirroring_sliding_window(self, x, weight=1.0, window_halfwidth=2):
-        """ Note: this method makes sense according to the consistency restriction for "larger" windows. """
+    def update_mirroring_sliding_window(self, x, weight=1.0,
+                                        window_halfwidth=2):
+        """ Note: this method makes sense according to the consistency
+        restriction for "larger" windows.
+        """
         num_samples, dim = x.shape
-        width = window_halfwidth  # window_halfwidth is too long to write it complete each time
+        # window_halfwidth is too long to write it complete each time
+        width = window_halfwidth
         if 2 * width >= num_samples:
-            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            ex = "window_halfwidth %d not supported for %d samples" % \
+                 (width, num_samples)
             raise TrainingException(ex)
 
         # Update Cov Matrix. All samples have same weight
@@ -709,12 +829,15 @@ class CovDCovMatrix(object):
         sum_prod_x_full = mdp.utils.mult(x_full.T, x_full)
 
         Aacc123 = numx.zeros((dim, dim))
-        for i in range(0, 2 * width):  # [0, 2*width-1]
-            Aacc123 += (i + 1) * mdp.utils.mult(x_mirror[i:i + 1, :].T, x_mirror[i:i + 1, :])  # (i+1)=1,2,3..., 2*width
+        for i in range(0, 2 * width):
+            Aacc123 += (i + 1) * mdp.utils.mult(x_mirror[i:i + 1, :].T,
+                                                x_mirror[i:i + 1, :])
 
-        for i in range(num_samples, num_samples + 2 * width):  # [num_samples-width, num_samples-1]
-            Aacc123 += (num_samples + 2 * width - i) * mdp.utils.mult(x_mirror[i:i + 1, :].T, x_mirror[i:i + 1, :])
-        x_middle = x_mirror[2 * width:-2 * width, :]  # intermediate values of x, which are connected 2*width+1 times
+        for i in range(num_samples, num_samples + 2 * width):
+            Aacc123 += (num_samples + 2 * width - i) * mdp.utils.mult(
+                x_mirror[i:i + 1, :].T, x_mirror[i:i + 1, :])
+        # intermediate values of x, which are connected 2*width+1 times
+        x_middle = x_mirror[2 * width:-2 * width, :]
         Aacc123 += (2 * width + 1) * mdp.utils.mult(x_middle.T, x_middle)
 
         b = numx.zeros((num_samples + 1 + 2 * width, dim))
@@ -722,17 +845,20 @@ class CovDCovMatrix(object):
         B = b[2 * width + 1:] - b[0:-2 * width - 1]
         Bprod = mdp.utils.mult(x_full.T, B)
 
-        sum_prod_diffs_full = (2 * width + 1) * sum_prod_x_full + Aacc123 - Bprod - Bprod.T
+        sum_prod_diffs_full = (2 * width + 1) * sum_prod_x_full + Aacc123 - \
+                              Bprod - Bprod.T
         num_diffs = num_samples * (2 * width)  # removed zero differences
         self.add_diffs(sum_prod_diffs_full, num_diffs, weight)
 
-
-    def update_slow_mirroring_sliding_window(self, x, weight=1.0, window_halfwidth=2):
-        """ This is an unoptimized version of update_mirroring_sliding_window. """
+    def update_slow_mirroring_sliding_window(self, x, weight=1.0,
+                                             window_halfwidth=2):
+        """ This is an unoptimized version of update_mirroring_sliding_window.
+        """
         num_samples, dim = x.shape
-        width = window_halfwidth  # window_halfwidth is way too long to write it
+        width = window_halfwidth
         if 2 * width >= num_samples:
-            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            ex = "window_halfwidth %d not supported for %d samples" % (width,
+                                                                        num_samples)
             raise TrainingException(ex)
 
         # Update Cov Matrix. All samples have same weight
@@ -740,7 +866,7 @@ class CovDCovMatrix(object):
         sum_prod_x = mdp.utils.mult(x.T, x)
         self.add_samples(sum_prod_x, sum_x, num_samples, weight)
 
-        # Update DCov Matrix. window = numx.ones(2*width+1) # Rectangular window
+        # Update DCov Matrix. window = numx.ones(2*width+1), rectangular window
         x_mirror = numx.zeros((num_samples + 2 * width, dim))
         x_mirror[width:-width] = x  # center part
         x_mirror[0:width, :] = x[0:width, :][::-1, :]  # start of the sequence
@@ -750,19 +876,21 @@ class CovDCovMatrix(object):
             if offset == 0:
                 pass
             else:
-                diffs = x_mirror[offset + width:offset + width + num_samples, :] - x
+                diffs = x_mirror[offset + width:offset + width +
+                                                num_samples, :] - x
 
                 sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
                 num_diffs = len(diffs)
                 self.add_diffs(sum_prod_diffs, num_diffs, weight)
 
-
-    def update_slow_truncating_sliding_window(self, x, weight=1.0, window_halfwidth=2):
+    def update_slow_truncating_sliding_window(self, x, weight=1.0,
+                                              window_halfwidth=2):
         """ Truncating Window (original slow/reference version). """
         num_samples, dim = x.shape
-        width = window_halfwidth  # window_halfwidth is way too long to write it
+        width = window_halfwidth
         if 2 * width >= num_samples:
-            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            ex = "window_halfwidth %d not supported for %d samples" % (width,
+                                                                        num_samples)
             raise ValueError(ex)
 
         # Update Cov Matrix. All samples have same weight
@@ -770,13 +898,16 @@ class CovDCovMatrix(object):
         sum_prod_x = mdp.utils.mult(x.T, x)
         self.add_samples(sum_prod_x, sum_x, num_samples, weight)
 
-        # Update DCov Matrix. window = numx.ones(2*width+1) # Rectangular window
+        # Update DCov Matrix. window = numx.ones(2*width+1), rectangular window
         x_extended = numx.zeros((num_samples + 2 * width, dim))
-        x_extended[width:-width] = x  # center part is preserved, extreme samples are zero
+        # Center part is preserved, extreme samples are zero
+        x_extended[width:-width] = x
 
-        # Negative offset is not considered because it is equivalent to the positive one, thereore the factor 2
+        # Negative offset is not considered because it is equivalent to the
+        # positive one, thereore the factor 2
         for offset in range(1, width + 1):
-            diffs = x_extended[offset + width:width + num_samples, :] - x[0:-offset, :]
+            diffs = x_extended[offset + width:width + num_samples, :] - \
+                    x[0:-offset, :]
             sum_prod_diffs = 2 * mdp.utils.mult(diffs.T, diffs)
             num_diffs = 2 * (num_samples - offset)
             self.add_diffs(sum_prod_diffs, num_diffs, weight)
@@ -786,7 +917,8 @@ class CovDCovMatrix(object):
         num_samples, dim = x.shape
         width = window_halfwidth
         if 2 * width >= num_samples:
-            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            ex = "window_halfwidth %d not supported for %d samples" % (width,
+                                                                        num_samples)
             raise ValueError(ex)
 
         # MOST CORRECT VERSION
@@ -799,8 +931,9 @@ class CovDCovMatrix(object):
         x_sel[-width:, :] = x_sel[-width:, :] * w_down
 
         sum_x = x_sel.sum(axis=0)
-        sum_prod_x = mdp.utils.mult(x_sel.T, x)  # There was a bug here, x_sel used twice!!!
-        self.add_samples(sum_prod_x, sum_x, num_samples - (0.5 * window_halfwidth - 0.5), weight)
+        sum_prod_x = mdp.utils.mult(x_sel.T, x)
+        self.add_samples(sum_prod_x, sum_x,
+                         num_samples - (0.5 * window_halfwidth - 0.5), weight)
 
         # Update DCov Matrix. First we compute the borders
         # Left border
@@ -812,7 +945,7 @@ class CovDCovMatrix(object):
             # print "sum_prod_diffs[0]=", sum_prod_diffs[0]
             self.add_diffs(sum_prod_diffs, num_diffs, weight)
         # Right border
-        for i in range(num_samples - width, num_samples):  # [num_samples-width, num_samples-1]
+        for i in range(num_samples - width, num_samples):
             diffs = x[i - width:num_samples, :] - x[i, :]
             sum_prod_diffs = mdp.utils.mult(diffs.T, diffs)
             num_diffs = len(diffs) - 1  # removed zero differences
@@ -826,11 +959,11 @@ class CovDCovMatrix(object):
 
         Aacc123 = numx.zeros((dim, dim))
         for i in range(0, 2 * width):  # [0, 2*width-1]
-            Aacc123 += (i + 1) * mdp.utils.mult(x[i:i + 1, :].T, x[i:i + 1, :])  # (i+1)=1,2,3..., 2*width
+            Aacc123 += (i + 1) * mdp.utils.mult(x[i:i + 1, :].T, x[i:i + 1, :])
 
-        for i in range(num_samples - 2 * width, num_samples):  # [num_samples-width, num_samples-1]
+        for i in range(num_samples - 2 * width, num_samples):
             Aacc123 += (num_samples - i) * mdp.utils.mult(x[i:i + 1, :].T,
-                                                          x[i:i + 1, :])  # (num_samples-1)=2*width,...,3,2,1
+                                                          x[i:i + 1, :])
 
         # intermediate values of x, which are connected 2*width+1 times
         x_middle = x[2 * width:num_samples - 2 * width, :]
@@ -839,21 +972,19 @@ class CovDCovMatrix(object):
 
         b = numx.zeros((num_samples + 1, dim))
         b[1:] = x.cumsum(axis=0)
-        #        for i in range(1,num_samples+1):
-        #            b[i] = b[i-1] + x[i-1,:]
-        #        A = a[2*width+1:]-a[0:-2*width-1]
         B = b[2 * width + 1:] - b[0:-2 * width - 1]
-        #        Aacc = A.sum(axis=0)
         Bprod = mdp.utils.mult(x_full.T, B)
-        sum_prod_diffs_full = (2 * width + 1) * sum_prod_x_full + Aacc123 - Bprod - Bprod.T
-        num_diffs = (num_samples - 2 * width) * (2 * width)  # removed zero differences
+        sum_prod_diffs_full = (2 * width + 1) * sum_prod_x_full + Aacc123 - \
+                              Bprod - Bprod.T
+        num_diffs = (num_samples - 2 * width) * (2 * width)
         self.add_diffs(sum_prod_diffs_full, num_diffs, weight)
 
     def update_sliding_window(self, x, weight=1.0, window_halfwidth=2):
         num_samples, dim = x.shape
         width = window_halfwidth
         if 2 * width >= num_samples:
-            ex = "window_halfwidth %d not supported for %d samples!" % (width, num_samples)
+            ex = "window_halfwidth %d not supported for %d samples" % \
+                 (width, num_samples)
             raise ValueError(ex)
 
         # MOST CORRECT VERSION
@@ -866,11 +997,10 @@ class CovDCovMatrix(object):
         x_sel[-width:, :] = x_sel[-width:, :] * w_down
 
         sum_x = x_sel.sum(axis=0)
-        sum_prod_x = mdp.utils.mult(x_sel.T, x)  # Bug fixed!!! computing w * X^T * X, with X=(x1,..xN)^T
-        self.add_samples(sum_prod_x, sum_x, num_samples - (0.5 * window_halfwidth - 0.5), weight)  # weights verified
+        sum_prod_x = mdp.utils.mult(x_sel.T, x)
+        self.add_samples(sum_prod_x, sum_x, num_samples -
+                         (0.5 * window_halfwidth - 0.5), weight)
 
-        # window = numx.ones(2*width+1). Rectangular window, used always here!
-        # diffs = numx.zeros((num_samples - 2 * width, dim))
         # This can be made faster (twice) due to symmetry
         for offset in range(-width, width + 1):
             if offset == 0:
@@ -890,23 +1020,22 @@ class CovDCovMatrix(object):
             raise TrainingException(er)
 
         if isinstance(block_size, numx.ndarray):
-            err = "Inhomogeneous block sizes not yet supported in update_serial"
+            err = "Inhomogeneous block sizes not yet supported"
             raise ValueError(err)
         elif isinstance(block_size, list):
             block_size_0 = block_size[0]
             for bs in block_size:
                 if bs != block_size_0:
-                    er = "for serial graph all groups must have same group size (block_size constant), but " + \
+                    er = "for serial graph all groups must have same group" + \
+                         "size (block_size constant), but " + \
                          str(bs) + "!=" + str(block_size_0)
                     raise ValueError(er)
             block_size = block_size_0
 
         if num_samples % block_size > 0:
-            err = "Consistency error: num_samples is not a multiple of block_size"
+            err = "num_samples is not a multiple of block_size"
             raise ValueError(err)
         num_blocks = num_samples // block_size
-
-        # warning, plenty of dtype missing!!!!!!!!
 
         # Correlation Matrix. Computing sum of outer products (the easy part)
         xp = x[block_size:num_samples - block_size]
@@ -914,8 +1043,9 @@ class CovDCovMatrix(object):
         x_b_end = x[num_samples - block_size:]
         sum_x = x_b_ini.sum(axis=0) + 2 * xp.sum(axis=0) + x_b_end.sum(axis=0)
 
-        sum_prod_x = mdp.utils.mult(x_b_ini.T, x_b_ini) + 2 * mdp.utils.mult(xp.T, xp) + mdp.utils.mult(x_b_end.T,
-                                                                                                        x_b_end)
+        sum_prod_x = mdp.utils.mult(x_b_ini.T, x_b_ini) + \
+                     2 * mdp.utils.mult(xp.T, xp) + \
+                     mdp.utils.mult(x_b_end.T, x_b_end)
         num_samples = 2 * block_size + 2 * (num_samples - 2 * block_size)
 
         self.add_samples(sum_prod_x, sum_x, num_samples, weight)
@@ -923,64 +1053,70 @@ class CovDCovMatrix(object):
         # DCorrelation Matrix. Compute medias signal
         media = numx.zeros((num_blocks, dim))
         for i in range(num_blocks):
-            media[i] = x[i * block_size:(i + 1) * block_size].sum(axis=0) * (1.0 / block_size)
+            media[i] = x[i * block_size:(i + 1) * block_size].sum(axis=0) * \
+                       (1.0 / block_size)
 
         media_a = media[0:-1]
         media_b = media[1:]
-        sum_prod_mixed_meds = (mdp.utils.mult(media_a.T, media_b) + mdp.utils.mult(media_b.T, media_a))
-        prod_first_block = mdp.utils.mult(x[0:block_size].T, x[0:block_size])
-        prod_last_block = mdp.utils.mult(x[num_samples - block_size:].T, x[num_samples - block_size:])
+        sum_prod_mixed_meds = (mdp.utils.mult(media_a.T, media_b) +
+                               mdp.utils.mult(media_b.T, media_a))
 
         num_diffs = block_size * (num_blocks - 1)
 
-        sum_prod_diffs = (block_size * sum_prod_x -
-                          (block_size * block_size) * sum_prod_mixed_meds) * (1.0 / block_size)
-        self.add_diffs(2 * sum_prod_diffs, 2 * num_diffs, weight)  # NEW: Factor 2 to account for both directions
+        sum_prod_diffs = (block_size * sum_prod_x - block_size * block_size
+                          * sum_prod_mixed_meds) * (1.0 / block_size)
+        # The factor 2 accounts for both directions
+        self.add_diffs(2 * sum_prod_diffs, 2 * num_diffs, weight)
 
     # Weight should refer to node weights
-    def update_clustered(self, x, block_sizes=None, weight=1.0, include_self_loops=True):
+    def update_clustered(self, x, block_sizes=None, weight=1.0,
+                         include_self_loops=True):
         num_samples, dim = x.shape
 
         if isinstance(block_sizes, int):
-            return self.update_clustered_homogeneous_block_sizes(x, weight=weight, block_size=block_sizes,
-                                                                 include_self_loops=include_self_loops)
+            return self.update_clustered_homogeneous_block_sizes(
+                x, weight=weight, block_size=block_sizes,
+                include_self_loops=include_self_loops)
 
         if block_sizes is None:
-            er = "error, block_size not specified!!!!"
+            er = "block_size is not specified"
             raise TrainingException(er)
 
         if num_samples != numx.array(block_sizes).sum():
-            err = "Inconsistency error: num_samples (%d) is not equal to sum of block_sizes:" % num_samples, block_sizes
+            err = "Inconsistency error: num_samples (%d)" % num_samples + \
+                "is not equal to sum of block_sizes: %d" % block_sizes
             raise ValueError(err)
 
         counter_sample = 0
         for block_size in block_sizes:
             normalized_weight = weight
-            self.update_clustered_homogeneous_block_sizes(x[counter_sample:counter_sample + block_size, :],
-                                                          weight=normalized_weight, block_size=block_size,
-                                                          include_self_loops=include_self_loops)
+            self.update_clustered_homogeneous_block_sizes(
+                x[counter_sample:counter_sample + block_size, :],
+                weight=normalized_weight, block_size=block_size,
+                include_self_loops=include_self_loops)
             counter_sample += block_size
 
-    def update_clustered_homogeneous_block_sizes(self, x, weight=1.0, block_size=None, include_self_loops=True):
+    def update_clustered_homogeneous_block_sizes(self, x, weight=1.0,
+                                                 block_size=None,
+                                                 include_self_loops=True):
         if self.verbose:
             print("update_clustered_homogeneous_block_sizes ")
         if block_size is None:
-            er = "error, block_size not specified!!!!"
+            er = "block_size is not specified"
             raise TrainingException(er)
 
         if isinstance(block_size, numx.ndarray):
-            er = "Error: inhomogeneous block sizes not supported by this function"
+            er = "inhomogeneous block sizes are not supported by this function"
             raise TrainingException(er)
 
         # Assuming block_size is an integer:
         num_samples, dim = x.shape
         if num_samples % block_size > 0:
-            err = "Inconsistency error: num_samples (%d) is not a multiple of block_size (%d)" % \
+            err = "num_samples (%d) is not a multiple of block_size (%d)" % \
                   (num_samples, block_size)
             raise ValueError(err)
         num_blocks = num_samples // block_size
 
-        # warning, plenty of dtype missing! they are just derived from the data.
         sum_x = x.sum(axis=0)
         sum_prod_x = mdp.utils.mult(x.T, x)
         self.add_samples(sum_prod_x, sum_x, num_samples, weight)
@@ -988,23 +1124,27 @@ class CovDCovMatrix(object):
         # DCorrelation Matrix. Compute medias signal
         media = numx.zeros((num_blocks, dim))
         for i in range(num_blocks):
-            media[i] = x[i * block_size:(i + 1) * block_size].sum(axis=0) * (1.0 / block_size)
+            media[i] = x[i * block_size:(i + 1) * block_size].sum(axis=0) * \
+                       (1.0 / block_size)
 
         sum_prod_meds = mdp.utils.mult(media.T, media)
-        # FIX1: AFTER DT in (0,4) normalization
-        num_diffs = num_blocks * block_size  # * (block_size-1+1) / (block_size-1)
+        num_diffs = num_blocks * block_size
         if self.verbose:
-            print("num_diffs in block:", num_diffs, " num_samples:", num_samples)
+            print("num_diffs in block:", num_diffs,
+                  " num_samples:", num_samples)
         if include_self_loops:
-            sum_prod_diffs = 2.0 * block_size * (sum_prod_x - block_size * sum_prod_meds) / block_size
+            sum_prod_diffs = 2.0 * block_size * (sum_prod_x - block_size *
+                                                 sum_prod_meds) / block_size
         else:
-            sum_prod_diffs = 2.0 * block_size * (sum_prod_x - block_size * sum_prod_meds) / (block_size - 1)
+            sum_prod_diffs = 2.0 * block_size * (sum_prod_x - block_size *
+                                            sum_prod_meds) / (block_size - 1)
 
         self.add_diffs(sum_prod_diffs, num_diffs, weight)
         if self.verbose:
-            print("(Diag(complete)/num_diffs.avg)**0.5 =", ((numx.diagonal(sum_prod_diffs) / num_diffs).mean()) ** 0.5)
+            print("(Diag(complete)/num_diffs.avg)**0.5 =",
+                  ((numx.diagonal(sum_prod_diffs) / num_diffs).mean()) ** 0.5)
 
-    def update_compact_classes(self, x, block_sizes=None, Jdes=None, weight=1.0):
+    def update_compact_classes(self, x, block_sizes=None, Jdes=None):
         num_samples, dim = x.shape
 
         if self.verbose:
@@ -1015,20 +1155,22 @@ class CovDCovMatrix(object):
         if isinstance(block_sizes, numx.ndarray):
             if len(block_sizes) > 1:
                 if block_sizes.var() > 0:
-                    er = "for compact_classes all groups must have the same number of elements (block_sizes)!!!!"
+                    er = "for compact_classes all groups must have the " + \
+                         "same number of elements (block_sizes)"
                     raise ValueError(er)
                 else:
                     block_size = block_sizes[0]
             else:
                 block_size = block_sizes[0]
         elif block_sizes is None:
-            er = "error, block_size not specified!!!!"
+            er = "block_size not specified"
             raise TrainingException(er)
         else:
             block_size = block_sizes
 
         if num_samples % block_size != 0:
-            err = "Inconsistency error: num_samples (%d) must be a multiple of block_size: " % num_samples, block_sizes
+            err = "num_samples (%d) should be a multiple of block_size: %d" % \
+                  (num_samples, block_sizes)
             raise ValueError(err)
 
         num_classes = num_samples // block_size
@@ -1038,17 +1180,21 @@ class CovDCovMatrix(object):
         extra_label = Jdes - J
 
         if self.verbose:
-            print("Besides J=%d labels, also adding %d labels" % (J, extra_label))
+            print("Besides J=%d labels, also adding %d labels" % (J,
+                                                                  extra_label))
 
         if num_classes != 2 ** J:
-            err = "Inconsistency error: num_clases %d does not appear to be a power of 2" % num_classes
+            err = "num_clases %d is probably not a power of 2" % num_classes
             raise ValueError(err)
 
         N = num_samples
         labels = numx.zeros((N, J + extra_label))
         for j in range(J):
-            labels[:, j] = (numx.arange(N) // block_size // (2 ** (J - j - 1)) % 2) * 2 - 1
-        eigenvalues = numx.concatenate(([1.0] * (J - 1), numx.arange(1.0, 0.0, -1.0 / (extra_label + 1))))
+            labels[:, j] = (numx.arange(N) // block_size //
+                            (2 ** (J - j - 1)) % 2) * 2 - 1
+        eigenvalues = numx.concatenate(([1.0] * (J - 1),
+                                        numx.arange(1.0, 0.0,
+                                                    -1.0 / (extra_label + 1))))
 
         n_taken = [2 ** k for k in range(J)]
         n_free = list(set(range(num_classes)) - set(n_taken))
@@ -1076,37 +1222,48 @@ class CovDCovMatrix(object):
 
         for j in range(J + extra_label):
             set10 = x[labels[:, j] == -1]
-            self.update_clustered_homogeneous_block_sizes(set10, weight=eigenvalues[j],
-                                                          block_size=N // 2)  # first cluster
+            # first cluster
+            self.update_clustered_homogeneous_block_sizes(
+                set10, weight=eigenvalues[j], block_size=N // 2)
             set10 = x[labels[:, j] == 1]
-            self.update_clustered_homogeneous_block_sizes(set10, weight=eigenvalues[j],
-                                                          block_size=N // 2)  # second cluster
+            # second cluster
+            self.update_clustered_homogeneous_block_sizes(
+                set10, weight=eigenvalues[j], block_size=N // 2)
 
-    def add_cov_dcov_matrix(self, cov_dcov_mat, adding_weight=1.0, own_weight=1.0):
+    def add_cov_dcov_matrix(self, cov_dcov_mat, adding_weight=1.0,
+                            own_weight=1.0):
         if self.sum_prod_x is None:
             self.sum_prod_x = cov_dcov_mat.sum_prod_x * adding_weight
             self.sum_x = cov_dcov_mat.sum_x * adding_weight
         else:
-            self.sum_prod_x = self.sum_prod_x * own_weight + cov_dcov_mat.sum_prod_x * adding_weight
-            self.sum_x = self.sum_x * own_weight + cov_dcov_mat.sum_x * adding_weight
-        self.num_samples = self.num_samples * own_weight + cov_dcov_mat.num_samples * adding_weight
+            self.sum_prod_x = self.sum_prod_x * own_weight + \
+                              cov_dcov_mat.sum_prod_x * adding_weight
+            self.sum_x = self.sum_x * own_weight + \
+                         cov_dcov_mat.sum_x * adding_weight
+        self.num_samples = self.num_samples * own_weight + \
+                           cov_dcov_mat.num_samples * adding_weight
         if self.sum_prod_diffs is None:
             self.sum_prod_diffs = cov_dcov_mat.sum_prod_diffs * adding_weight
         else:
-            self.sum_prod_diffs = self.sum_prod_diffs * own_weight + cov_dcov_mat.sum_prod_diffs * adding_weight
-        self.num_diffs = self.num_diffs * own_weight + cov_dcov_mat.num_diffs * adding_weight
+            self.sum_prod_diffs = self.sum_prod_diffs * own_weight + \
+                                  cov_dcov_mat.sum_prod_diffs * adding_weight
+        self.num_diffs = self.num_diffs * own_weight + \
+                         cov_dcov_mat.num_diffs * adding_weight
 
-    def fix(self, divide_by_num_samples_or_differences=True, center_dcov=False):  # include_tail=False,
+    def fix(self, divide_by_num_samples_or_differences=True):
         if self.verbose:
             print("Fixing CovDCovMatrix")
 
         avg_x = self.sum_x * (1.0 / self.num_samples)
 
         prod_avg_x = numx.outer(avg_x, avg_x)
-        if divide_by_num_samples_or_differences:  # as specified by the theory on training graphs
-            cov_x = (self.sum_prod_x - self.num_samples * prod_avg_x) / (1.0 * self.num_samples)
+        if divide_by_num_samples_or_differences:
+            # as specified by the theory on training graphs
+            cov_x = (self.sum_prod_x -
+                     self.num_samples * prod_avg_x) / (1.0 * self.num_samples)
         else:  # standard unbiased estimation used by standard SFA
-            cov_x = (self.sum_prod_x - self.num_samples * prod_avg_x) / (self.num_samples - 1.0)
+            cov_x = (self.sum_prod_x -
+                     self.num_samples * prod_avg_x) / (self.num_samples - 1.0)
 
         # Finalize covariance matrix of dx
         if divide_by_num_samples_or_differences or True:
@@ -1119,90 +1276,120 @@ class CovDCovMatrix(object):
         self.dcov_mtx = cov_dx
 
         if self.verbose:
-            print("Finishing training CovDcovMtx:", self.num_samples, "num_samples, and", self.num_diffs, "num_diffs")
+            print("Finishing training CovDcovMtx:", self.num_samples,
+                  "num_samples, and", self.num_diffs, "num_diffs")
             print("Avg[0:3] is", self.avg[0:4])
-            print("Prod_avg_x[0:3,0:3] is", prod_avg_x[0:3,0:3])
-            print("Cov[0:3,0:3] is", self.cov_mtx[0:3,0:3])
-            print("DCov[0:3,0:3] is", self.dcov_mtx[0:3,0:3])
-            print("AvgDiff[0:4] is", avg_diff[0:4])
-            print("Prod_avg_diff[0:3,0:3] is", prod_avg_diff[0:3,0:3])
-            print("Sum_prod_diffs[0:3,0:3] is", self.sum_prod_diffs[0:3,0:3])
-            print("exp_prod_diffs[0:3,0:3] is", exp_prod_diffs[0:3,0:3])
+            print("Prod_avg_x[0:3,0:3] is", prod_avg_x[0:3, 0:3])
+            print("Cov[0:3,0:3] is", self.cov_mtx[0:3, 0:3])
+            print("DCov[0:3,0:3] is", self.dcov_mtx[0:3, 0:3])
+            # print("AvgDiff[0:4] is", avg_diff[0:4])
+            # print("Prod_avg_diff[0:3,0:3] is", prod_avg_diff[0:3,0:3])
+            print("Sum_prod_diffs[0:3,0:3] is", self.sum_prod_diffs[0:3, 0:3])
+            # print("exp_prod_diffs[0:3,0:3] is", exp_prod_diffs[0:3,0:3])
         return self.cov_mtx, self.avg, self.dcov_mtx
 
 
 class iGSFANode(mdp.Node):
-    """This node implements "information-preserving graph-based SFA (iGSFA)", which is the main component of
-    hierarchical iGSFA (HiGSFA).
+    """This node implements "information-preserving graph-based SFA (iGSFA)",
+    which is the main component of hierarchical iGSFA (HiGSFA).
 
-    For further information, see: Escalante-B., A.-N. and Wiskott, L., "Improved graph-based {SFA}: Information
-    preservation complements the slowness principle", e-print arXiv:1601.03945, http://arxiv.org/abs/1601.03945, 2017
+    For further information, see: Escalante-B., A.-N. and Wiskott, L.,
+    "Improved graph-based {SFA}: Information preservation complements the
+    slowness principle", e-print arXiv:1601.03945,
+    http://arxiv.org/abs/1601.03945, 2017.
     """
 
-    def __init__(self, pre_expansion_node_class=None, pre_expansion_out_dim=None,
-                 expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
-                 max_length_slow_part=None, slow_feature_scaling_method=None, delta_threshold=1.999,
-                 reconstruct_with_sfa=False, verbose=False, input_dim=None, output_dim=None, dtype=None, **argv):
+    def __init__(self, pre_expansion_node_class=None,
+                 pre_expansion_out_dim=None, expansion_funcs=None,
+                 expansion_output_dim=None, expansion_starting_point=None,
+                 max_length_slow_part=None, slow_feature_scaling_method=None,
+                 delta_threshold=1.999, reconstruct_with_sfa=False,
+                 verbose=False, input_dim=None, output_dim=None,
+                 dtype=None, **argv):
         """Initializes the iGSFA node.
 
-        pre_expansion_node_class: a node class. An instance of this class is used to filter the data before the
-                                  expansion.
-        pre_expansion_out_dim: the output dimensionality of the above-mentioned node.
-        expansion_funcs: a list of expansion functions to be applied before GSFA.
-        expansion_output_dim: this parameter is used to specify an output dimensionality for some expansion functions.
-        expansion_starting_point: this parameter is also used by some specific expansion functions.
-        max_length_slow_part: fixes an upper bound to the size of the slow part, which is convenient for
-                              computational reasons.
-        slow_feature_scaling_method: the method used to scale the slow features. Valid entries are: None,
-                         "sensitivity_based" (default), "data_dependent", and "QR_decomposition".
-        delta_threshold: this parameter has two different meanings depending on its type. If it is real valued (e.g.,
-                         1.99), it determines the parameter \Delta_threshold, which is used to decide how many slow
-                         features are preserved, depending on their delta values. If it is integer (e.g., 20), it
-                         directly specifies the exact size of the slow part.
-        reconstruct_with_sfa: this Boolean parameter indicates whether the slow part is removed from the input before
-                              PCA is applied.
+        pre_expansion_node_class: a node class. An instance of this class is
+            used to filter the data before the expansion.
+        pre_expansion_out_dim: the output dimensionality of the
+            above-mentioned node.
+        expansion_funcs: a list of expansion functions to be applied before
+            GSFA.
+        expansion_output_dim: this parameter is used to specify an output
+            dimensionality for some expansion functions.
+        expansion_starting_point: this parameter is also used by some specific
+            expansion functions.
+        max_length_slow_part: fixes an upper bound to the size of the slow
+            part, which is convenient for computational reasons.
+        slow_feature_scaling_method: the method used to scale the slow
+            features. Valid entries are: None, "sensitivity_based" (default),
+            "data_dependent", and "QR_decomposition".
+        delta_threshold: this parameter has two different meanings depending
+            on its type. If it is real valued (e.g., 1.99), it determines the
+            parameter \Delta_threshold, which is used to decide how many slow
+            features are preserved, depending on their delta values. If it is
+            integer (e.g., 20), it directly specifies the exact size of the
+            slow part.
+        reconstruct_with_sfa: this Boolean parameter indicates whether the
+            slow part is removed from the input before PCA is applied.
 
-        More information about parameters 'expansion_funcs' and 'expansion_starting_point' can be found in the
-            documentation of GeneralExpansionNode.
+        More information about parameters 'expansion_funcs' and
+            'expansion_starting_point' can be found in the documentation of
+            GeneralExpansionNode.
 
-        Note: Training sometimes finishes after a single call to the train method, unless multi-train is enabled
-              (default). Multi-train is enabled by setting reconstruct_with_sfa=False and
-              slow_feature_scaling_method in [None, "data_dependent"]. This is necessary to support weight sharing in
-              iGSFA layers (convolutional iGSFA layers).
+        Note: Training sometimes finishes after a single call to the train
+            method, unless multi-train is enabled (default). Multi-train is
+            enabled by setting reconstruct_with_sfa=False and
+            slow_feature_scaling_method in [None, "data_dependent"].
+            This is necessary to support weight sharing in iGSFA layers
+            (convolutional iGSFA layers).
         """
-        super(iGSFANode, self).__init__(input_dim=input_dim, output_dim=output_dim, dtype=dtype, **argv)
-        self.pre_expansion_node_class = pre_expansion_node_class  # Type of node used to expand the data
+        super(iGSFANode, self).__init__(input_dim=input_dim,
+                                        output_dim=output_dim,
+                                        dtype=dtype, **argv)
+        # Type of node used to expand the data
+        self.pre_expansion_node_class = pre_expansion_node_class
         self.pre_expansion_node = None  # Node that expands the input data
         self.pre_expansion_output_dim = pre_expansion_out_dim
-        self.expansion_output_dim = expansion_output_dim  # Expanded dimensionality
-        self.expansion_starting_point = expansion_starting_point  # Initial parameters for the expansion function
+        # Expanded dimensionality
+        self.expansion_output_dim = expansion_output_dim
+        # Initial parameters for the expansion function
+        self.expansion_starting_point = expansion_starting_point
 
         # creates an expansion node
-        if expansion_funcs:
-            self.exp_node = GeneralExpansionNode(funcs=expansion_funcs, output_dim=self.expansion_output_dim,
-                                                 starting_point=self.expansion_starting_point)
+        if expansion_funcs and self.expansion_output_dim is not None:
+            self.exp_node = GeneralExpansionNode(
+                funcs=expansion_funcs, output_dim=self.expansion_output_dim,
+                starting_point=self.expansion_starting_point)
+        elif expansion_funcs:
+            self.exp_node = GeneralExpansionNode(
+                funcs=expansion_funcs,
+                starting_point=self.expansion_starting_point)
         else:
             self.exp_node = None
 
         self.sfa_node = None
         self.pca_node = None
         self.lr_node = None
-        self.max_length_slow_part = max_length_slow_part  # upper limit to the size of the slow part
+        # hard upper limit to the size of the slow part
+        self.max_length_slow_part = max_length_slow_part
 
-        # Parameter that defines the size of the slow part. Its meaning depnds on wheather it is an integer or a float
+        # Parameter that defines the size of the slow part. Its meaning
+        # depends on wheather it is an integer or a float
         self.delta_threshold = delta_threshold
-        # Indicates whether (nonlinear) SFA components are used for reconstruction
+        # Indicates whether (nonlinear) SFA components are used for
+        # reconstruction
         self.reconstruct_with_sfa = reconstruct_with_sfa
         # Indicates how to scale the slow part
         self.slow_feature_scaling_method = slow_feature_scaling_method
 
-        # Default verbose value if none is explicity provided to the class methods
+        # Default value when none is explicity provided to the class methods
         self.verbose = verbose
 
         # Dimensionality of the data after the expansion function
         self.expanded_dim = None
 
-        # The following variables are for internal use only (available after training on a single batch only)
+        # The following variables are for internal use only (available after
+        # training on a single batch only)
         self.x_mean = None
         self.sfa_x_mean = None
         self.sfa_x_std = None
@@ -1212,11 +1399,13 @@ class iGSFANode(mdp.Node):
         return True
 
     # TODO: should train_mode be renamed training_mode?
-    def _train(self, x, block_size=None, train_mode=None, node_weights=None, edge_weights=None, verbose=None, **argv):
+    def _train(self, x, block_size=None, train_mode=None, node_weights=None,
+               edge_weights=None, verbose=None, **argv):
         """Trains an iGSFA node on data 'x'
 
-        The parameters:  block_size, train_mode, node_weights, and edge_weights are passed to the training function of
-        the corresponding gsfa node inside iGSFA (node.gsfa_node).
+        The parameters:  block_size, train_mode, node_weights, and edge_weights
+        are passed to the training function of the corresponding gsfa node
+        inside iGSFA (node.gsfa_node).
         """
         self.input_dim = x.shape[1]
         if verbose is None:
@@ -1228,14 +1417,21 @@ class iGSFANode(mdp.Node):
         if verbose:
             print("Training iGSFANode...")
 
-        if (not self.reconstruct_with_sfa) and (self.slow_feature_scaling_method in [None, "data_dependent"]):
-            self.multiple_train(x, block_size=block_size, train_mode=train_mode, node_weights=node_weights,
+        if (not self.reconstruct_with_sfa) and \
+                (self.slow_feature_scaling_method in [None, "data_dependent"]):
+            self.multiple_train(x, block_size=block_size,
+                                train_mode=train_mode,
+                                node_weights=node_weights,
                                 edge_weights=edge_weights)
             return
 
-        if (not self.reconstruct_with_sfa) and (self.slow_feature_scaling_method not in [None, "data_dependent"]):
-            er = "'reconstruct_with_sfa' (" + str(self.reconstruct_with_sfa) + ") must be True when the scaling" + \
-                 "method (" + str(self.slow_feature_scaling_method) + ") is neither 'None' not 'data_dependent'"
+        if (not self.reconstruct_with_sfa) and \
+                (self.slow_feature_scaling_method not in [None,
+                                                          "data_dependent"]):
+            er = "'reconstruct_with_sfa' " + str(self.reconstruct_with_sfa) + \
+                 ") should be True when the scaling method (" + \
+                 str(self.slow_feature_scaling_method) + \
+                 ") is neither 'None' not 'data_dependent'"
             raise TrainingException(er)
         # else continue using the regular method:
 
@@ -1243,12 +1439,15 @@ class iGSFANode(mdp.Node):
         self.x_mean = x.mean(axis=0)
         x_zm = x - self.x_mean
 
-        # Reorder or pre-process the data before it is expanded, but only if there is really an expansion
+        # Reorder or pre-process the data before it is expanded,
+        # but only if there is really an expansion
         if self.pre_expansion_node_class and self.exp_node:
-            self.pre_expansion_node = self.pre_expansion_node_class(output_dim=self.pre_expansion_output_dim)
-            # reasonable options are pre_expansion_node_class = GSFANode or WhitheningNode
+            self.pre_expansion_node = self.pre_expansion_node_class(
+                output_dim=self.pre_expansion_output_dim)
+            # reasonable options for pre_expansion_node_class are GSFANode
+            # or WhitheningNode
             self.pre_expansion_node.train(x_zm, block_size=block_size,
-                                          train_mode=train_mode)  # Some arguments might not be necessary
+                                          train_mode=train_mode)
             self.pre_expansion_node.stop_training()
             x_pre_exp = self.pre_expansion_node.execute(x_zm)
         else:
@@ -1267,35 +1466,44 @@ class iGSFANode(mdp.Node):
         if self.max_length_slow_part is None:
             sfa_output_dim = min(self.expanded_dim, self.output_dim)
         else:
-            sfa_output_dim = min(self.max_length_slow_part, self.expanded_dim, self.output_dim)
+            sfa_output_dim = min(self.max_length_slow_part, self.expanded_dim,
+                                 self.output_dim)
 
         if isinstance(self.delta_threshold, int):
             sfa_output_dim = min(sfa_output_dim, self.delta_threshold)
             sfa_output_dim = max(1, sfa_output_dim)
 
         # Apply SFA to expanded data
-        self.sfa_node = GSFANode(output_dim=sfa_output_dim, dtype=self.dtype, verbose=verbose)
-        self.sfa_node.train(exp_x, block_size=block_size, train_mode=train_mode,
-                            node_weights=node_weights, edge_weights=edge_weights)  # sfa_node.train_params
+        self.sfa_node = GSFANode(output_dim=sfa_output_dim, dtype=self.dtype,
+                                 verbose=verbose)
+        self.sfa_node.train(exp_x, block_size=block_size,
+                            train_mode=train_mode, node_weights=node_weights,
+                            edge_weights=edge_weights)  # sfa_node.train_params
         self.sfa_node.stop_training()
         if verbose:
             print("self.sfa_node.d", self.sfa_node.d)
 
-        # Decide how many slow features are preserved (either use Delta_T=delta_threshold when
-        # delta_threshold is a float, or preserve delta_threshold features when delta_threshold is an integer)
+        # Decide how many slow features are preserved (either use
+        # Delta_T=delta_threshold when delta_threshold is a float, or
+        # preserve delta_threshold features when delta_threshold is an integer)
         if isinstance(self.delta_threshold, float):
             # here self.max_length_slow_part should be considered
-            self.num_sfa_features_preserved = (self.sfa_node.d <= self.delta_threshold).sum()
+            self.num_sfa_features_preserved = (self.sfa_node.d <=
+                                               self.delta_threshold).sum()
         elif isinstance(self.delta_threshold, int):
             # here self.max_length_slow_part should be considered
             self.num_sfa_features_preserved = self.delta_threshold
             if self.delta_threshold > self.output_dim:
-                er = "The provided integer delta_threshold %d is larger than the allowed output dimensionality %d" % \
+                er = "The provided integer delta_threshold " + \
+                     "%d is larger than the output dimensionality %d" % \
                      (self.delta_threshold, self.output_dim)
                 raise ValueError(er)
-            if self.max_length_slow_part is not None and self.delta_threshold > self.max_length_slow_part:
-                er = "The provided integer delta_threshold %d" % self.delta_threshold + \
-                     " is larger than the given upper bound on the size of the slow part (max_length_slow_part) %d" % \
+            if self.max_length_slow_part is not None and \
+                            self.delta_threshold > self.max_length_slow_part:
+                er = "The provided integer delta_threshold " + \
+                     "%d" % self.delta_threshold + \
+                     " is larger than the given upper bound on the size " + \
+                     "of the slow part (max_length_slow_part) %d" % \
                      self.max_length_slow_part
                 raise ValueError(er)
 
@@ -1306,7 +1514,8 @@ class iGSFANode(mdp.Node):
         if self.num_sfa_features_preserved > self.output_dim:
             self.num_sfa_features_preserved = self.output_dim
 
-        SFANode_reduce_output_dim(self.sfa_node, self.num_sfa_features_preserved)
+        SFANode_reduce_output_dim(self.sfa_node,
+                                  self.num_sfa_features_preserved)
         if verbose:
             print("sfa execute...")
         sfa_x = self.sfa_node.execute(exp_x)
@@ -1325,11 +1534,12 @@ class iGSFANode(mdp.Node):
         if self.reconstruct_with_sfa:
             x_pca = x_zm
 
-            # approximate input linearly, done inline to preserve node for future use
+            # Approximate input linearly
             if verbose:
                 print("training linear regression...")
             self.lr_node = mdp.nodes.LinearRegressionNode()
-            # Notice that the input "x"=n_sfa_x and the output to learn is "y" = x_pca
+            # Notice that the input data is "x"=n_sfa_x and the output
+            # to learn is "y" = x_pca
             self.lr_node.train(n_sfa_x, x_pca)
             self.lr_node.stop_training()
             x_pca_app = self.lr_node.execute(n_sfa_x)
@@ -1344,16 +1554,19 @@ class iGSFANode(mdp.Node):
         if verbose:
             print("ranking method...")
         # A method for feature scaling( +rotation)
-        if self.reconstruct_with_sfa and self.slow_feature_scaling_method == "QR_decomposition":
-            M = self.lr_node.beta[1:, :].T  # bias is used by default, we do not need to consider it
+        if self.reconstruct_with_sfa and \
+                        self.slow_feature_scaling_method == "QR_decomposition":
+            # A bias term is included by default, we do not need it
+            M = self.lr_node.beta[1:, :].T
             Q, R = numx.linalg.qr(M)
             self.Q = Q
             self.R = R
             self.Rpinv = pinv(R)
             s_n_sfa_x = numx.dot(n_sfa_x, R.T)
         # Another method for feature scaling (no rotation)
-        elif self.reconstruct_with_sfa and (self.slow_feature_scaling_method == "sensitivity_based"):
-            beta = self.lr_node.beta[1:, :]  # bias is used by default, we do not need to consider it
+        elif self.reconstruct_with_sfa and \
+                (self.slow_feature_scaling_method == "sensitivity_based"):
+            beta = self.lr_node.beta[1:, :]
             sens = (beta ** 2).sum(axis=1)
             self.magn_n_sfa_x = sens ** 0.5
             s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
@@ -1368,17 +1581,20 @@ class iGSFANode(mdp.Node):
             if verbose:
                 print("skiped data_dependent")
         else:
-            er = "unknown slow feature scaling method= " + str(self.slow_feature_scaling_method) + \
+            er = "unknown slow feature scaling method= " + \
+                 str(self.slow_feature_scaling_method) + \
                  " for reconstruct_with_sfa= " + str(self.reconstruct_with_sfa)
             raise ValueError(er)
 
         print("training PCA...")
         pca_output_dim = self.output_dim - self.num_sfa_features_preserved
         # This allows training of PCA when pca_out_dim is zero
-        self.pca_node = mdp.nodes.PCANode(output_dim=max(1, pca_output_dim), dtype=self.dtype)
+        self.pca_node = mdp.nodes.PCANode(output_dim=max(1, pca_output_dim),
+                                          dtype=self.dtype)
         self.pca_node.train(sfa_removed_x)
         self.pca_node.stop_training()
-        PCANode_reduce_output_dim(self.pca_node, pca_output_dim, verbose=False)
+        PCANode_reduce_output_dim(self.pca_node, pca_output_dim,
+                                  verbose=False)
 
         # TODO:check that pca_out_dim > 0
         if verbose:
@@ -1389,26 +1605,32 @@ class iGSFANode(mdp.Node):
         if self.slow_feature_scaling_method == "data_dependent":
             if pca_output_dim > 0:
                 self.magn_n_sfa_x = 1.0 * numx.median(
-                    self.pca_node.d) ** 0.5  # WARNING, why did I have 5.0 there? it is supposed to be 1.0
+                    self.pca_node.d) ** 0.5
             else:
                 self.magn_n_sfa_x = 1.0
-            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x  # Scale according to ranking
+            s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
             if verbose:
                 print("method: data dependent")
 
-        if self.pca_node.output_dim + self.num_sfa_features_preserved < self.output_dim:
-            er = "Error, the number of features computed is SMALLER than the output dimensionality of the node: " + \
-                 "self.pca_node.output_dim=" + str(self.pca_node.output_dim) + ", self.num_sfa_features_preserved=" + \
-                 str(self.num_sfa_features_preserved) + ", self.output_dim=" + str(self.output_dim)
+        if self.pca_node.output_dim + self.num_sfa_features_preserved < \
+                self.output_dim:
+            er = "Error, the number of features computed is SMALLER than " \
+                 + "the output dimensionality of the node: " + \
+                 "self.pca_node.output_dim=" + str(self.pca_node.output_dim) \
+                 + ", self.num_sfa_features_preserved=" + \
+                 str(self.num_sfa_features_preserved) + ", self.output_dim=" \
+                 + str(self.output_dim)
             raise TrainingException(er)
 
-        # Finally, the output is the concatenation of scaled slow features and remaining pca components
+        # Finally, the output is the concatenation of scaled slow features
+        # and remaining pca components
         sfa_pca_x = numx.concatenate((s_n_sfa_x, pca_x), axis=1)
 
         sfa_pca_x_truncated = sfa_pca_x[:, 0:self.output_dim]
 
-        # Compute explained variance from amplitudes of output compared to amplitudes of input
-        # Only works because amplitudes of SFA are scaled to be equal to explained variance, because PCA is
+        # Compute explained variance from amplitudes of output compared to
+        # amplitudes of input. Only works because amplitudes of SFA are
+        # scaled to be equal to explained variance, because PCA is
         # a rotation, and because data has zero mean
         self.evar = (sfa_pca_x_truncated ** 2).sum() / (x_zm ** 2).sum()
         if verbose:
@@ -1417,11 +1639,12 @@ class iGSFANode(mdp.Node):
             print("Variance(output) / Variance(input) is ", self.evar)
         self.stop_training()
 
-    def multiple_train(self, x, block_size=None, train_mode=None, node_weights=None,
-                       edge_weights=None, verbose=None):
-        """This function should not be called directly. Use instead the train method, which will decide whether
-        multiple-training is enabled, and call this function if needed. """
-        # TODO: is the following line needed? or also self.set_input_dim? or self._input_dim?
+    def multiple_train(self, x, block_size=None, train_mode=None,
+                       node_weights=None, edge_weights=None, verbose=None):
+        """This function should not be called directly. Use instead the train
+        method, which will decide whether multiple-training is enabled, and
+        call this function if needed.
+        """
         self.input_dim = x.shape[1]
         if verbose is None:
             verbose = self.verbose
@@ -1434,7 +1657,8 @@ class iGSFANode(mdp.Node):
             self.x_mean = numx.zeros(self.input_dim, dtype=self.dtype)
         x_zm = x
 
-        # Reorder or pre-process the data before it is expanded, but only if there is really an expansion.
+        # Reorder or pre-process the data before it is expanded, but only if
+        # there is really an expansion.
         if self.pre_expansion_node_class and self.exp_node:
             er = "Unexpected parameters"
             raise TrainingException(er)
@@ -1453,7 +1677,8 @@ class iGSFANode(mdp.Node):
         if self.max_length_slow_part is None:
             sfa_output_dim = min(self.expanded_dim, self.output_dim)
         else:
-            sfa_output_dim = min(self.max_length_slow_part, self.expanded_dim, self.output_dim)
+            sfa_output_dim = min(self.max_length_slow_part, self.expanded_dim,
+                                 self.output_dim)
 
         if isinstance(self.delta_threshold, int):
             sfa_output_dim = min(sfa_output_dim, self.delta_threshold)
@@ -1461,25 +1686,31 @@ class iGSFANode(mdp.Node):
 
         # Apply SFA to expanded data
         if self.sfa_node is None:
-            self.sfa_node = GSFANode(output_dim=sfa_output_dim, verbose=verbose)
+            self.sfa_node = GSFANode(output_dim=sfa_output_dim,
+                                     verbose=verbose)
         self.sfa_x_mean = 0
         self.sfa_x_std = 1.0
 
-        self.sfa_node.train(exp_x, block_size=block_size, train_mode=train_mode,
-                            node_weights=node_weights, edge_weights=edge_weights)
+        self.sfa_node.train(exp_x, block_size=block_size,
+                            train_mode=train_mode,
+                            node_weights=node_weights,
+                            edge_weights=edge_weights)
 
         if verbose:
             print("training PCA...")
         pca_output_dim = self.output_dim
         if self.pca_node is None:
-            self.pca_node = mdp.nodes.PCANode(output_dim=pca_output_dim)  # evetually, add: reduce=True
+            # If necessary, add reduce=True
+            self.pca_node = mdp.nodes.PCANode(output_dim=pca_output_dim)
         sfa_removed_x = x
         self.pca_node.train(sfa_removed_x)
 
     def _stop_training(self, verbose=None):
         if verbose is None:
             verbose = self.verbose
-        if self.reconstruct_with_sfa or (self.slow_feature_scaling_method not in [None, "data_dependent"]):
+        if self.reconstruct_with_sfa or \
+                (self.slow_feature_scaling_method not in [None,
+                                                          "data_dependent"]):
             return
         # else, continue with multi-train method
 
@@ -1488,41 +1719,51 @@ class iGSFANode(mdp.Node):
             print("self.sfa_node.d", self.sfa_node.d)
         self.pca_node.stop_training()
 
-        # Decide how many slow features are preserved (either use Delta_T=delta_threshold when
-        # delta_threshold is a float, or preserve delta_threshold features when delta_threshold is an integer)
+        # Decide how many slow features are preserved
         if isinstance(self.delta_threshold, float):
             # here self.max_length_slow_part should be considered
-            self.num_sfa_features_preserved = (self.sfa_node.d <= self.delta_threshold).sum()
+            self.num_sfa_features_preserved = (self.sfa_node.d <=
+                                               self.delta_threshold).sum()
         elif isinstance(self.delta_threshold, int):
             # here self.max_length_slow_part should be considered
             self.num_sfa_features_preserved = self.delta_threshold
             if self.delta_threshold > self.output_dim:
-                er = "The provided integer delta_threshold %d is larger than the allowed output dimensionality %d" % \
+                er = "The provided integer delta_threshold " + \
+                     "%d is larger than the output dimensionality %d" % \
                      (self.delta_threshold, self.output_dim)
                 raise ValueError(er)
-            if self.max_length_slow_part is not None and self.delta_threshold > self.max_length_slow_part:
-                er = "The provided integer delta_threshold %d" % self.delta_threshold + \
-                     " is larger than the given upper bound on the size of the slow part (max_length_slow_part) %d" % \
+            if self.max_length_slow_part is not None and \
+                            self.delta_threshold > self.max_length_slow_part:
+                er = "The provided integer delta_threshold: %d" % \
+                     self.delta_threshold + \
+                     " is larger than max_length_slow_part: %d" % \
                      self.max_length_slow_part
                 raise ValueError(er)
         else:
-            ex = "Cannot handle type of self.delta_threshold:" + str(type(self.delta_threshold))
+            ex = "Cannot handle type of self.delta_threshold:" + \
+                 str(type(self.delta_threshold))
             raise ValueError(ex)
 
         if self.num_sfa_features_preserved > self.output_dim:
             self.num_sfa_features_preserved = self.output_dim
 
-        SFANode_reduce_output_dim(self.sfa_node, self.num_sfa_features_preserved)
+        SFANode_reduce_output_dim(self.sfa_node,
+                                  self.num_sfa_features_preserved)
         if verbose:
             print("size of slow part:", self.num_sfa_features_preserved)
 
-        final_pca_node_output_dim = self.output_dim - self.num_sfa_features_preserved
+        final_pca_node_output_dim = self.output_dim - \
+                                    self.num_sfa_features_preserved
         if final_pca_node_output_dim > self.pca_node.output_dim:
-            er = "Error, the number of features computed is SMALLER than the output dimensionality of the node: " + \
-                 "self.pca_node.output_dim=" + str(self.pca_node.output_dim) + ", self.num_sfa_features_preserved=" + \
-                 str(self.num_sfa_features_preserved) + ", self.output_dim=" + str(self.output_dim)
+            er = "The number of features computed is SMALLER than the " + \
+                 "output dimensionality of the node: " + \
+                 "pca_node.output_dim=" + str(self.pca_node.output_dim) + \
+                 ", num_sfa_features_preserved=" + \
+                 str(self.num_sfa_features_preserved) + \
+                 ", output_dim=" + str(self.output_dim)
             raise ValueError(er)
-        PCANode_reduce_output_dim(self.pca_node, final_pca_node_output_dim, verbose=False)
+        PCANode_reduce_output_dim(self.pca_node, final_pca_node_output_dim,
+                                  verbose=False)
 
         if verbose:
             print("self.pca_node.d", self.pca_node.d)
@@ -1532,7 +1773,8 @@ class iGSFANode(mdp.Node):
             if verbose:
                 print("method: constant amplitude for all slow features")
         elif self.slow_feature_scaling_method == "data_dependent":
-            # SFA components have an std equal to that of the least significant principal component
+            # SFA components are given a variance equal to the median variance
+            # of the principal components
             if self.pca_node.d.shape[0] > 0:
                 self.magn_n_sfa_x = 1.0 * numx.median(self.pca_node.d) ** 0.5
             else:
@@ -1540,7 +1782,8 @@ class iGSFANode(mdp.Node):
             if verbose:
                 print("method: data dependent")
         else:
-            er = "Unknown slow feature scaling method" + str(self.slow_feature_scaling_method)
+            er = "Unknown slow feature scaling method" + \
+                 str(self.slow_feature_scaling_method)
             raise ValueError(er)
         self.evar = self.pca_node.explained_variance
 
@@ -1549,7 +1792,9 @@ class iGSFANode(mdp.Node):
         return True
 
     def _execute(self, x):
-        """Extracts iGSFA features from some data. The node must have been already trained. """
+        """Extracts iGSFA features from some data. The node must have been
+        already trained.
+        """
         x_zm = x - self.x_mean
 
         if self.pre_expansion_node:
@@ -1577,17 +1822,20 @@ class iGSFANode(mdp.Node):
         sfa_removed_x = x_zm - x_app
 
         # A method for feature scaling( +rotation)
-        if self.reconstruct_with_sfa and self.slow_feature_scaling_method == "QR_decomposition":
+        if self.reconstruct_with_sfa \
+                and self.slow_feature_scaling_method == "QR_decomposition":
             s_n_sfa_x = numx.dot(n_sfa_x, self.R.T)
         # Another method for feature scaling (no rotation)
-        elif self.reconstruct_with_sfa and self.slow_feature_scaling_method == "sensitivity_based":
+        elif self.reconstruct_with_sfa \
+                and self.slow_feature_scaling_method == "sensitivity_based":
             s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
         elif self.slow_feature_scaling_method is None:
             s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
         elif self.slow_feature_scaling_method == "data_dependent":
             s_n_sfa_x = n_sfa_x * self.magn_n_sfa_x
         else:
-            er = "unknown feature scaling method" + str(self.slow_feature_scaling_method)
+            er = "unknown feature scaling method" + \
+                 str(self.slow_feature_scaling_method)
             raise ValueError(er)
 
         # Apply PCA to sfa removed data
@@ -1597,15 +1845,18 @@ class iGSFANode(mdp.Node):
             # No reconstructive components present
             pca_x = numx.zeros((x.shape[0], 0))
 
-        # Finally output is the concatenation of scaled slow features and remaining pca components
+        # Finally output is the concatenation of scaled slow features and
+        # remaining pca components
         sfa_pca_x = numx.concatenate((s_n_sfa_x, pca_x), axis=1)
 
         return sfa_pca_x  # sfa_pca_x_truncated
 
     def _inverse(self, y, linear_inverse=True):
-        """This method approximates an inverse function to the feature extraction.
+        """This method approximates an inverse function to the feature
+        extraction.
 
-        if linear_inverse is True, a linear method is used. Otherwise, a gradient-based non-linear method is used.
+        If linear_inverse is True, a linear method is used. Otherwise, a
+        gradient-based non-linear method is used.
         """
         if linear_inverse:
             return self.linear_inverse(y)
@@ -1635,7 +1886,8 @@ class iGSFANode(mdp.Node):
         else:
             num_zeros_filling = 0
         if verbose:
-            print("x_dim=", x_dim, "y_dim=", y_dim, "num_zeros_filling=", num_zeros_filling)
+            print("x_dim=", x_dim, "y_dim=", y_dim, "num_zeros_filling=",
+                  num_zeros_filling)
         y_long = numx.zeros(y_dim + num_zeros_filling)
 
         for i, y_i in enumerate(y):
@@ -1643,7 +1895,9 @@ class iGSFANode(mdp.Node):
             if verbose:
                 print("x_0=", x_lin[i])
                 print("y_long=", y_long)
-            plsq = scipy.optimize.leastsq(func=f_residual, x0=x_lin[i], args=(self, y_long), full_output=False)
+            plsq = scipy.optimize.leastsq(func=f_residual, x0=x_lin[i],
+                                          args=(self, y_long),
+                                          full_output=False)
             x_nl_i = plsq[0]
             if verbose:
                 print("x_nl_i=", x_nl_i, "plsq[1]=", plsq[1])
@@ -1651,11 +1905,16 @@ class iGSFANode(mdp.Node):
                 print("Quitting: plsq[1]=", plsq[1])
             x_nl[i] = x_nl_i
             if verbose:
-                print("|E_lin(%d)|=" % i, ((y_i - self.execute(x_lin[i].reshape((1, -1)))) ** 2).sum() ** 0.5)
-                print("|E_nl(%d)|=" % i, ((y_i - self.execute(x_nl_i.reshape((1, -1)))) ** 2).sum() ** 0.5)
+                y_i_app = self.execute(x_lin[i].reshape((1, -1)))
+                print("|E_lin(%d)|=" % i,
+                      ((y_i - y_i_app) ** 2).sum() ** 0.5)
+                y_i_app = self.execute(x_nl_i.reshape((1, -1)))
+                print("|E_nl(%d)|=" % i,
+                      ((y_i - y_i_app) ** 2).sum() ** 0.5)
         rmse_nl = ((y - self.execute(x_nl)) ** 2).sum(axis=1).mean() ** 0.5
         if verbose:
-            print("rmse_lin(all samples)=", rmse_lin, "rmse_nl(all samples)=", rmse_nl)
+            print("rmse_lin(all samples)=", rmse_lin,
+                  "rmse_nl(all samples)=", rmse_nl)
         return x_nl
 
     def linear_inverse(self, y, verbose=True):
@@ -1664,11 +1923,13 @@ class iGSFANode(mdp.Node):
             verbose = self.verbose
         num_samples = y.shape[0]
         if y.shape[1] != self.output_dim:
-            er = "Serious dimensionality inconsistency:", y.shape[0], self.output_dim
+            er = "Serious dimensionality inconsistency"
             raise TrainingException(er)
 
         sfa_pca_x_full = numx.zeros(
-            (num_samples, self.pca_node.output_dim + self.num_sfa_features_preserved), dtype=self.dtype)
+            (num_samples,
+             self.pca_node.output_dim + self.num_sfa_features_preserved),
+            dtype=self.dtype)
         sfa_pca_x_full[:, 0:self.output_dim] = y
 
         s_n_sfa_x = sfa_pca_x_full[:, 0:self.num_sfa_features_preserved]
@@ -1680,12 +1941,13 @@ class iGSFANode(mdp.Node):
             sfa_removed_x = numx.zeros((num_samples, self.input_dim))
 
         # A method for feature scaling (+rotation)
-        if self.reconstruct_with_sfa and self.slow_feature_scaling_method == "QR_decomposition":
+        if self.reconstruct_with_sfa \
+                and self.slow_feature_scaling_method == "QR_decomposition":
             n_sfa_x = numx.dot(s_n_sfa_x, self.Rpinv.T)
         else:
             n_sfa_x = s_n_sfa_x / self.magn_n_sfa_x
 
-        # sfa_x is n_sfa_x * self.sfa_x_std + self.sfa_x_mean
+        # recall: sfa_x is n_sfa_x * self.sfa_x_std + self.sfa_x_mean
         if self.reconstruct_with_sfa:
             x_pca_app = self.lr_node.execute(n_sfa_x)
             x_app = x_pca_app
@@ -1711,8 +1973,7 @@ def SFANode_reduce_output_dim(sfa_node, new_output_dim, verbose=False):
     if verbose:
         print("Updating the output dimensionality of SFA node")
     if new_output_dim > sfa_node.output_dim:
-        er = "Can only reduce output dimensionality of SFA node, not increase it (%d > %d)" % \
-             (new_output_dim, sfa_node.output_dim)
+        er = "Cannot increase the output dimensionality of the SFA node"
         raise ValueError(er)
     sfa_node.d = sfa_node.d[:new_output_dim]
     sfa_node.sf = sfa_node.sf[:, :new_output_dim]
@@ -1723,12 +1984,13 @@ def SFANode_reduce_output_dim(sfa_node, new_output_dim, verbose=False):
 def PCANode_reduce_output_dim(pca_node, new_output_dim, verbose=False):
     """ This function modifies an already trained PCA node,
     reducing the number of preserved SFA features to new_output_dim features.
-    The modification is done in place. Also the explained variance field is updated
+    The modification is done in place. Also the explained variance field is
+    updated.
     """
     if verbose:
         print("Updating the output dimensionality of PCA node")
     if new_output_dim > pca_node.output_dim:
-        er = "Can only reduce output dimensionality of PCA node, not increase it"
+        er = "Cannot increase the output dimensionality of the PCA node"
         raise ValueError(er)
 
     original_total_variance = pca_node.d.sum()
@@ -1737,11 +1999,15 @@ def PCANode_reduce_output_dim(pca_node, new_output_dim, verbose=False):
     pca_node.v = pca_node.v[:, 0:new_output_dim]
     # pca_node.avg is not affected by this method!
     pca_node._output_dim = new_output_dim
-    pca_node.explained_variance = original_explained_variance * pca_node.d.sum() / original_total_variance
+    pca_node.explained_variance = \
+        original_explained_variance * \
+        pca_node.d.sum() / original_total_variance
 
 
-# Computes output errors dimension by dimension for a single sample: y - node.execute(x_app)
-# The library fails when dim(x_app) > dim(y), thus filling of x_app with zeros is recommended
+# Computes output errors dimension by dimension for a single sample:
+# y - node.execute(x_app)
+# The library fails when dim(x_app) > dim(y), thus filling of x_app with
+# zeros is recommended
 def f_residual(x_app_i, node, y_i):
     res_long = numx.zeros_like(y_i)
     y_i = y_i.reshape((1, -1))
@@ -1751,12 +2017,12 @@ def f_residual(x_app_i, node, y_i):
     return res_long
 
 
-#########################################################################################################
-#   EXAMPLES THAT SHOW HOW GSFA CAN BE USED                                                             #
-#########################################################################################################
+###############################################################################
+#   EXAMPLES THAT SHOW HOW GSFA CAN BE USED                                   #
+###############################################################################
 
 def example_clustered_graph():
-    print("\n**************************************************************************")
+    print("\n****************************************************************")
     print("*Example of training GSFA using a clustered graph")
     cluster_size = 20
     num_clusters = 5
@@ -1792,12 +2058,14 @@ def example_clustered_graph():
     x_test += 0.1 * numx.arange(num_samples).reshape((num_samples, 1))
     y_test = GSFA_n.execute(Exp_n.execute(x_test))
     print("y_test", y_test)
-    print("Standard delta values of output features y_test:", comp_delta(y_test))
+    print("Standard delta values of output features y_test:",
+          comp_delta(y_test))
 
 
 def example_pathological_outputs(experiment):
-    print("\n **************************************************************************")
-    print("*Pathological responses. Experiment on graph with weakly connected samples")
+    print("\n ***************************************************************")
+    print("*Pathological responses.",
+          "Experiment on graph with weakly connected samples")
     x = numx.random.normal(size=(20, 19))
     x2 = numx.random.normal(size=(20, 19))
 
@@ -1862,26 +2130,31 @@ def example_pathological_outputs(experiment):
         for j1 in range(19):
             for j2 in range(j1 + 1, 20):
                 e[(j1, j2)] = 1 / (l[j2] - l[j1] + 0.00005)
-        exp_title = "Modified edge weights for labels as w12 = 1/(l2-l1+0.00005). Experiment 7"
+        exp_title = "Modified edge weights for labels with " + \
+                    "w12 = 1/(l2-l1+0.00005). Experiment 7"
     elif experiment == 8:
         e = {}
         for j1 in range(19):
             for j2 in range(j1 + 1, 20):
                 e[(j1, j2)] = numx.exp(-0.25 * (l[j2] - l[j1]) ** 2)
-        exp_title = "Modified edge weights for labels as w12 = exp(-0.25*(l2-l1)**2). Experiment 8"
+        exp_title = "Modified edge weights for labels with " + \
+                    "w12 = exp(-0.25*(l2-l1)**2). Experiment 8"
     elif experiment == 9:
         e = {}
         for j1 in range(19):
             for j2 in range(j1 + 1, 20):
                 if l[j2] - l[j1] < 1.5:
                     e[(j1, j2)] = 1 / (l[j2] - l[j1] + 0.0005)
-        exp_title = "Modified edge weights w12 = 1/(l2-l1+0.0005), for l2-l1<1.5. Experiment 9"
+        exp_title = "Modified edge weights w12 = 1/(l2-l1+0.0005), " + \
+                    "for l2-l1<1.5. Experiment 9"
     elif experiment == 10:
-        exp_title = "Mirroring training graph, w=%d" % half_width + ". Experiment 10"
+        exp_title = "Mirroring training graph, w=%d" % half_width + \
+                    ". Experiment 10"
         train_mode = "smirror_window%d" % half_width
         e = {}
     elif experiment == 11:
-        exp_title = "Node weight adjustment training graph, w=%d " % half_width + ". Experiment 11"
+        exp_title = "Node weight adjustment training graph, w=%d " % \
+                    half_width + ". Experiment 11"
         train_mode = "window%d" % half_width
         e = {}
     else:
@@ -1912,8 +2185,9 @@ def example_pathological_outputs(experiment):
     import matplotlib.pyplot as plt
 
     plt.figure()
-    plt.title("Overfitted outputs on training data, v (node weights)=" + str(v))
-    plt.xlabel(exp_title + "\n With D (half the sum of all edges from/to each vertex)=" + str(D))
+    plt.title("Outputs overfitted to training data, node weights=" + str(v))
+    plt.xlabel(exp_title + "\n With D (half the sum of all edges " +
+               "from/to each vertex)=" + str(D))
     plt.xticks(numx.arange(0, 20, 1))
     plt.plot(y)
     if experiment in (6, 7, 8):
@@ -1924,7 +2198,7 @@ def example_pathological_outputs(experiment):
 
 
 def example_continuous_edge_weights():
-    print("\n**************************************************************************")
+    print("\n****************************************************************")
     print("*Testing continuous edge weigths w_{n,n'} = 1/(|l_n'-l_n|+k)")
     x = numx.random.normal(size=(20, 19))
     x2 = numx.random.normal(size=(20, 19))
@@ -1972,12 +2246,12 @@ def example_continuous_edge_weights():
     plt.show()
 
 
-########################################################################################
-#   AN EXAMPLE OF HOW iGSFA CAN BE USED                                                #
-########################################################################################
+###############################################################################
+#   AN EXAMPLE OF HOW iGSFA CAN BE USED                                       #
+###############################################################################
 
 def example_iGSFA():
-    print("\n\n**************************************************************************")
+    print("\n\n**************************************************************")
     print("*Example of training iGSFA on random data")
     num_samples = 1000
     dim = 20
@@ -1998,7 +2272,8 @@ def example_iGSFA():
         return x
 
     print("Node creation and training")
-    n = iGSFANode(output_dim=15, reconstruct_with_sfa=False, slow_feature_scaling_method="data_dependent",
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=False,
+                  slow_feature_scaling_method="data_dependent",
                   verbose=verbose)
     n.train(x, train_mode="regular")
     n.stop_training()
@@ -2009,11 +2284,14 @@ def example_iGSFA():
     print("y=", y)
     print("y_test=", y_test)
     print("Standard delta values of output features y:", comp_delta(y))
-    print("Standard delta values of output features y_test:", comp_delta(y_test))
+    print("Standard delta values of output features y_test:",
+          comp_delta(y_test))
     y_norm = zero_mean_unit_var(y)
     y_test_norm = zero_mean_unit_var(y_test)
-    print("Standard delta values of output features y after constraint enforcement:", comp_delta(y_norm))
-    print("Standard delta values of output features y_test after constraint enforcement:", comp_delta(y_test_norm))
+    print("Standard delta values of output features y after constraint ",
+          "enforcement:", comp_delta(y_norm))
+    print("Standard delta values of output features y_test after constraint ",
+          "enforcement:", comp_delta(y_test_norm))
 
     x_app_lin = n.inverse(y)
     x_app_nonlin = n.nonlinear_inverse(y)

--- a/mdp/test/test_GSFANode.py
+++ b/mdp/test/test_GSFANode.py
@@ -1,0 +1,311 @@
+#####################################################################################################################
+# test_GSFANode: Tests for the Graph-Based SFA Node (GSFANode) as defined by the Cuicuilco framework                #
+#                                                                                                                   #
+# By Alberto Escalante. Alberto.Escalante@ini.rub.de                                                                #
+# Ruhr-University Bochum, Institute for Neural Computation, Group of Prof. Dr. Wiskott                              #
+#####################################################################################################################
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+
+from past.utils import old_div
+from ._tools import *
+
+# import numx
+import pytest
+# import mdp
+
+from mdp.nodes.gsfa_nodes import graph_delta_values, comp_delta
+
+#TODO: test invalid parameters (training mode, block size, etc)
+
+
+def test_equivalence_SFA_GSFA_regular_mode():
+    """ Tests the equivalence of Standard SFA and GSFA when trained using the "regular" training mode
+    """
+    num_samples = 200
+    correction_factor_scale = ((num_samples - 1.0) / num_samples) ** 0.5
+    input_dim = 15
+    x = numx.random.normal(size=(num_samples, input_dim))
+    x2 = numx.random.normal(size=(num_samples, input_dim))
+
+    print("Training GSFA (regular mode):")
+    output_dim = 5
+    n = mdp.nodes.GSFANode(output_dim=output_dim)
+    n.train(x, train_mode="regular")
+    n.stop_training()
+
+    print("Training SFA:")
+    n_sfa = mdp.nodes.SFANode(output_dim=output_dim)
+    n_sfa.train(x)
+    n_sfa.stop_training()
+
+    y = n.execute(x)
+    y *= correction_factor_scale
+    assert y.shape[1] == output_dim, "Output dimensionality %d was supposed to be %d" % (y.shape[1], output_dim)
+    print("y[0]:", y[0])
+    print("y.mean:", y.mean(axis=0))
+    print("y.var:", (y**2).mean(axis=0))
+    y2 = n.execute(x2)
+    y2 *= correction_factor_scale
+
+    y_sfa = n_sfa.execute(x)
+    print("y_sfa[0]:", y_sfa[0])
+    print("y_sfa.mean:", y_sfa.mean(axis=0))
+    print("y_sfa.var:", (y_sfa**2).mean(axis=0))
+    y2_sfa = n_sfa.execute(x2)
+
+    signs_sfa = numx.sign(y_sfa[0,:])
+    signs_gsfa = numx.sign(y[0,:])
+    y = y * signs_gsfa * signs_sfa
+    y2 = y2 * signs_gsfa * signs_sfa
+
+    print("y_sfa:", y_sfa, "y:", y)
+    assert (y_sfa - y) == pytest.approx(0.0)
+    assert (y2_sfa - y2) == pytest.approx(0.0)
+
+
+def test_equivalence_GSFA_clustered_and_classification_modes():
+    """ Tests the equivalence of GSFA when trained using the "clustered" and "classification" training modes.
+
+    Notice that the clustered mode assumes the samples with the same labels are contiguous.
+    """
+    num_classes = 5
+    num_samples_per_class = numx.array([numx.random.randint(10, 30) for j in range(num_classes)])
+    num_samples = num_samples_per_class.sum()
+    classes = []
+    for i, j in enumerate(num_samples_per_class):
+        classes += [i] * j
+    classes = numx.array(classes)
+    print("classes:", classes)
+    input_dim = 15
+    x = numx.random.normal(size=(num_samples, input_dim))
+
+    print("Training GSFA (clustered mode):")
+    output_dim = num_classes - 1
+    n = mdp.nodes.GSFANode(output_dim=output_dim)
+    n.train(x, train_mode="clustered", block_size=num_samples_per_class)
+    n.stop_training()
+
+
+    sorting = numx.arange(num_samples)
+    numx.random.shuffle(sorting)
+    x_s = x[sorting]
+    classes_s = classes[sorting]
+    print("Training GSFA (classification mode):")
+    n2 = mdp.nodes.GSFANode(output_dim=output_dim)
+    n2.train(x_s, train_mode=("classification", classes_s, 1.0))
+    n2.stop_training()
+
+    y_clustered = n.execute(x)
+    print("reordering outputs of clustered mode")
+    y_clustered = y_clustered[sorting]
+    print("y_clustered[0]:", y_clustered[0])
+    print("y_clustered.mean:", y_clustered.mean(axis=0))
+    print("y_clustered.var:", (y_clustered**2).mean(axis=0))
+
+    y_classification = n2.execute(x_s)
+    print("y_classification[0]:", y_classification[0])
+    print("y_classification.mean:", y_classification.mean(axis=0))
+    print("y_classification.var:", (y_classification**2).mean(axis=0))
+
+
+    signs_gsfa_classification = numx.sign(y_classification[0,:])
+    signs_gsfa_clustered = numx.sign(y_clustered[0,:])
+    y_clustered = y_clustered * signs_gsfa_clustered * signs_gsfa_classification
+
+    assert (y_clustered - y_classification) == pytest.approx(0.0)
+
+
+def test_GSFA_zero_mean_unit_variance_graph():
+    """ Test of GSFA for zero-mean unit variance constraints on random data and graph, edge dictionary mode
+    """
+    x = numx.random.normal(size=(200, 15))
+    v = numx.ones(200)
+    e = {}
+    for i in range(1500):
+        n1 = numx.random.randint(200)
+        n2 = numx.random.randint(200)
+        e[(n1, n2)] = numx.random.normal() + 1.0
+    n = mdp.nodes.GSFANode(output_dim=5)
+    n.train(x, train_mode="graph", node_weights=v, edge_weights=e)
+    n.stop_training()
+
+    y = n.execute(x)
+    assert y.mean(axis=0) == pytest.approx(0.0)
+    assert (y**2).mean(axis=0) == pytest.approx(1.0)
+
+
+def test_basic_GSFA_edge_dict():
+    """ Basic test of GSFA on random data and graph, edge dictionary mode
+    """
+    x = numx.random.normal(size=(200, 15))
+    v = numx.ones(200)
+    e = {}
+    for i in range(1500):
+        n1 = numx.random.randint(200)
+        n2 = numx.random.randint(200)
+        e[(n1, n2)] = numx.random.normal() + 1.0
+    n = mdp.nodes.GSFANode(output_dim=5)
+    n.train(x, train_mode="graph", node_weights=v, edge_weights=e)
+    n.stop_training()
+
+    y = n.execute(x)
+    delta_values_training_data = graph_delta_values(y, e)
+
+    x2 = numx.random.normal(size=(200, 15))
+    y2 = n.execute(x2)
+    y2 = y2 - y2.mean(axis=0)  # enforce zero mean
+    y2 /= ((y2**2).mean(axis=0) ** 0.5)  # enforce zero-mean
+    # print("y2 means:", y2.mean(axis=0))
+    # print("y2 std:", (y2**2).mean(axis=0))
+
+    delta_values_test_data = graph_delta_values(y2, e)
+    assert (delta_values_training_data < delta_values_test_data).all()
+    # print("Graph delta values of training data", graph_delta_values(y, e))
+    # print("Graph delta values of test data (should be larger than for training)", graph_delta_values(y2, e))
+
+
+def test_equivalence_SFA_GSFA_linear_graph():
+    """ Tests the equivalence of Standard SFA and GSFA when trained using an appropriate linear graph (graph mode)
+    """
+    num_samples = 200
+    correction_factor_scale = ((num_samples - 1.0) / num_samples) ** 0.5
+    input_dim = 15
+    x = numx.random.normal(size=(num_samples, input_dim))
+    x2 = numx.random.normal(size=(num_samples, input_dim))
+
+    v = numx.ones(num_samples)
+    e = {}
+    for t in range(num_samples - 1):
+        e[(t, t + 1)] = 1.0
+    e[(0, 0)] = 0.5
+    e[(num_samples - 1, num_samples - 1)] = 0.5
+
+    print("Training GSFA:")
+    output_dim = 5
+    n = mdp.nodes.GSFANode(output_dim=output_dim)
+    n.train(x, train_mode="graph", node_weights=v, edge_weights=e)
+    n.stop_training()
+
+    print("Training SFA:")
+    n_sfa = mdp.nodes.SFANode(output_dim=output_dim)
+    n_sfa.train(x)
+    n_sfa.stop_training()
+
+    y = n.execute(x)
+    y *= correction_factor_scale
+    assert y.shape[1] == output_dim, "Output dimensionality %d was supposed to be %d" % (y.shape[1], output_dim)
+    print("y[0]:", y[0])
+    print("y.mean:", y.mean(axis=0))
+    print("y.var:", (y**2).mean(axis=0))
+    y2 = n.execute(x2)
+    y2 *= correction_factor_scale
+
+    y_sfa = n_sfa.execute(x)
+    print("y_sfa[0]:", y_sfa[0])
+    print("y_sfa.mean:", y_sfa.mean(axis=0))
+    print("y_sfa.var:", (y_sfa**2).mean(axis=0))
+    y2_sfa = n_sfa.execute(x2)
+
+    signs_sfa = numx.sign(y_sfa[0,:])
+    signs_gsfa = numx.sign(y[0,:])
+    y = y * signs_gsfa * signs_sfa
+    y2 = y2 * signs_gsfa * signs_sfa
+
+    assert (y_sfa - y) == pytest.approx(0.0)
+    assert (y2_sfa - y2) == pytest.approx(0.0)
+
+
+
+
+
+
+# FUTURE: Is it worth it to have so many methods? I guess the mirroring windows are enough, they have constant
+# node weights and the edge weights almost fulfill consistency
+def test_equivalence_window3_fwindow3():
+    """Tests the equivalence of slow and fast mirroring sliding windows for GSFA
+    """
+    x = numx.random.normal(size=(200, 15))
+    training_modes = ("window3", "fwindow3")
+
+    delta_values = []
+    for training_mode in training_modes:
+        n = mdp.nodes.GSFANode(output_dim=5)
+        n.train(x, train_mode=training_mode)
+        n.stop_training()
+
+        y = n.execute(x)
+        delta = comp_delta(y)
+        # print("**Brute Delta Values of mode %s are: " % training_mode, delta)
+        delta_values.append(delta)
+
+    # print(delta_values)
+    assert (delta_values[1] - delta_values[0]) == pytest.approx(0.0)
+
+
+def test_equivalence_smirror_window3_mirror_window3():
+    """Tests the equivalence of slow and fast mirroring sliding windows for GSFA
+    """
+    x = numx.random.normal(size=(200, 15))
+    training_modes = ("smirror_window3", "mirror_window3")
+
+    delta_values = []
+    for training_mode in training_modes:
+        n = mdp.nodes.GSFANode(output_dim=5)
+        n.train(x, train_mode=training_mode)
+        n.stop_training()
+
+        y = n.execute(x)
+        delta = comp_delta(y)
+        # print("**Brute Delta Values of mode %s are: " % training_mode, delta)
+        delta_values.append(delta)
+
+    # print(delta_values)
+    assert (delta_values[1] - delta_values[0]) == pytest.approx(0.0)
+
+
+def test_equivalence_smirror_window32_mirror_window32():
+    """Tests the equivalence of slow and fast mirroring sliding windows for GSFA
+    """
+    x = numx.random.normal(size=(200, 15))
+    training_modes = ("smirror_window32", "mirror_window32")
+
+    delta_values = []
+    for training_mode in training_modes:
+        n = mdp.nodes.GSFANode(output_dim=5)
+        n.train(x, train_mode=training_mode)
+        n.stop_training()
+
+        y = n.execute(x)
+        delta = comp_delta(y)
+        # print("**Brute Delta Values of mode %s are: " % training_mode, delta)
+        delta_values.append(delta)
+
+    # print(delta_values)
+    assert (delta_values[1] - delta_values[0]) == pytest.approx(0.0)
+
+
+def test_equivalence_update_graph_and_update_graph_old():
+    """ Basic test of GSFA on random data and graph, edge dictionary mode
+    """
+    x = numx.random.normal(size=(200, 15))
+    v = numx.ones(200)
+    e = {}
+    for i in range(1500):
+        n1 = numx.random.randint(200)
+        n2 = numx.random.randint(200)
+        e[(n1, n2)] = numx.random.normal() + 1.0
+    n = mdp.nodes.GSFANode(output_dim=5)
+    n.train(x, train_mode="graph", node_weights=v, edge_weights=e)
+    n.stop_training()
+    y = n.execute(x)
+
+    n2 = mdp.nodes.GSFANode(output_dim=5)
+    n2.train(x, train_mode="graph_old", node_weights=v, edge_weights=e)
+    n2.stop_training()
+    y2 = n2.execute(x)
+
+    assert (y - y2) == pytest.approx(0.0)
+

--- a/mdp/test/test_GSFANode.py
+++ b/mdp/test/test_GSFANode.py
@@ -1,9 +1,6 @@
-#####################################################################################################################
-# test_GSFANode: Tests for the Graph-Based SFA Node (GSFANode)                                                      #
-#                                                                                                                   #
-# By Alberto Escalante. Alberto.Escalante@ini.rub.de                                                                #
-# Ruhr-University Bochum, Institute for Neural Computation, Group of Prof. Dr. Wiskott                              #
-#####################################################################################################################
+###############################################################################
+# test_GSFANode: Tests for the Graph-Based SFA Node (GSFANode)                #
+###############################################################################
 
 from __future__ import absolute_import
 from __future__ import print_function
@@ -14,7 +11,8 @@ from mdp.nodes.gsfa_nodes import graph_delta_values, comp_delta
 
 
 def test_equivalence_SFA_GSFA_regular_mode():
-    """ Tests the equivalence of Standard SFA and GSFA when trained using the "regular" training mode
+    """ Tests the equivalence of Standard SFA and GSFA when trained using
+    the "regular" training mode.
     """
     num_samples = 200
     correction_factor_scale = ((num_samples - 1.0) / num_samples) ** 0.5
@@ -35,7 +33,9 @@ def test_equivalence_SFA_GSFA_regular_mode():
 
     y = n.execute(x)
     y *= correction_factor_scale
-    assert y.shape[1] == output_dim, "Output dimensionality %d was supposed to be %d" % (y.shape[1], output_dim)
+    assert y.shape[1] == output_dim, \
+        "Output dimensionality %d was supposed to be %d" % (y.shape[1],
+                                                            output_dim)
     print("y[0]:", y[0])
     print("y.mean:", y.mean(axis=0))
     print("y.var:", (y**2).mean(axis=0))
@@ -48,8 +48,8 @@ def test_equivalence_SFA_GSFA_regular_mode():
     print("y_sfa.var:", (y_sfa**2).mean(axis=0))
     y2_sfa = n_sfa.execute(x2)
 
-    signs_sfa = numx.sign(y_sfa[0,:])
-    signs_gsfa = numx.sign(y[0,:])
+    signs_sfa = numx.sign(y_sfa[0, :])
+    signs_gsfa = numx.sign(y[0, :])
     y = y * signs_gsfa * signs_sfa
     y2 = y2 * signs_gsfa * signs_sfa
 
@@ -58,12 +58,15 @@ def test_equivalence_SFA_GSFA_regular_mode():
 
 
 def test_equivalence_GSFA_clustered_and_classification_modes():
-    """ Tests the equivalence of GSFA when trained using the "clustered" and "classification" training modes.
+    """ Tests the equivalence of GSFA when trained using the "clustered" and
+    "classification" training modes.
 
-    Notice that the clustered mode assumes the samples with the same labels are contiguous.
+    Notice that the clustered mode assumes the samples with the same labels
+    are contiguous.
     """
     num_classes = 5
-    num_samples_per_class = numx.array([numx.random.randint(10, 30) for j in range(num_classes)])
+    num_samples_per_class = numx.array([numx.random.randint(10, 30)
+                                        for _ in range(num_classes)])
     num_samples = num_samples_per_class.sum()
     classes = []
     for i, j in enumerate(num_samples_per_class):
@@ -78,7 +81,6 @@ def test_equivalence_GSFA_clustered_and_classification_modes():
     n = mdp.nodes.GSFANode(output_dim=output_dim)
     n.train(x, train_mode="clustered", block_size=num_samples_per_class)
     n.stop_training()
-
 
     sorting = numx.arange(num_samples)
     numx.random.shuffle(sorting)
@@ -101,16 +103,17 @@ def test_equivalence_GSFA_clustered_and_classification_modes():
     print("y_classification.mean:", y_classification.mean(axis=0))
     print("y_classification.var:", (y_classification**2).mean(axis=0))
 
-
-    signs_gsfa_classification = numx.sign(y_classification[0,:])
-    signs_gsfa_clustered = numx.sign(y_clustered[0,:])
-    y_clustered = y_clustered * signs_gsfa_clustered * signs_gsfa_classification
+    signs_gsfa_classification = numx.sign(y_classification[0, :])
+    signs_gsfa_clustered = numx.sign(y_clustered[0, :])
+    y_clustered = y_clustered * signs_gsfa_clustered \
+                  * signs_gsfa_classification
 
     assert_array_almost_equal(y_clustered, y_classification, decimal)
 
 
 def test_GSFA_zero_mean_unit_variance_graph():
-    """ Test of GSFA for zero-mean unit variance constraints on random data and graph, edge dictionary mode
+    """ Test of GSFA for zero-mean unit variance constraints on random data
+    and graph, edge dictionary mode.
     """
     x = numx.random.normal(size=(200, 15))
     v = numx.ones(200)
@@ -131,7 +134,7 @@ def test_GSFA_zero_mean_unit_variance_graph():
 
 
 def test_basic_GSFA_edge_dict():
-    """ Basic test of GSFA on random data and graph, edge dictionary mode
+    """ Basic test of GSFA on random data and graph, edge dictionary mode.
     """
     x = numx.random.normal(size=(200, 15))
     v = numx.ones(200)
@@ -153,11 +156,13 @@ def test_basic_GSFA_edge_dict():
     y2 /= ((y2**2).mean(axis=0) ** 0.5)  # enforce unit variance
 
     delta_values_test_data = graph_delta_values(y2, e)
-    assert (delta_values_test_data - delta_values_training_data > -1.5 * 10 ** -decimal).all()
+    assert (delta_values_test_data - delta_values_training_data >
+            -1.5 * 10 ** -decimal).all()
 
 
 def test_equivalence_SFA_GSFA_linear_graph():
-    """ Tests the equivalence of Standard SFA and GSFA when trained using an appropriate linear graph (graph mode)
+    """ Tests the equivalence of Standard SFA and GSFA when trained using an
+    appropriate linear graph (graph mode).
     """
     num_samples = 200
     correction_factor_scale = ((num_samples - 1.0) / num_samples) ** 0.5
@@ -185,7 +190,9 @@ def test_equivalence_SFA_GSFA_linear_graph():
 
     y = n.execute(x)
     y *= correction_factor_scale
-    assert y.shape[1] == output_dim, "Output dimensionality %d was supposed to be %d" % (y.shape[1], output_dim)
+    assert y.shape[1] == output_dim, \
+        "Output dimensionality %d was supposed to be %d" % (y.shape[1],
+                                                            output_dim)
     print("y[0]:", y[0])
     print("y.mean:", y.mean(axis=0))
     print("y.var:", (y**2).mean(axis=0))
@@ -198,8 +205,8 @@ def test_equivalence_SFA_GSFA_linear_graph():
     print("y_sfa.var:", (y_sfa**2).mean(axis=0))
     y2_sfa = n_sfa.execute(x2)
 
-    signs_sfa = numx.sign(y_sfa[0,:])
-    signs_gsfa = numx.sign(y[0,:])
+    signs_sfa = numx.sign(y_sfa[0, :])
+    signs_gsfa = numx.sign(y[0, :])
     y = y * signs_gsfa * signs_sfa
     y2 = y2 * signs_gsfa * signs_sfa
 
@@ -207,10 +214,12 @@ def test_equivalence_SFA_GSFA_linear_graph():
     assert_array_almost_equal(y2_sfa, y2, decimal)
 
 
-# FUTURE: Is it worth it to have so many methods? I guess the mirroring windows are enough, they have constant
-# node weights and the edge weights almost fulfill consistency
+# FUTURE: Is it worth it to have so many methods? I guess the mirroring
+# windows are enough, they have constant node weights and the edge weights
+# almost fulfill consistency
 def test_equivalence_window3_fwindow3():
-    """Tests the equivalence of slow and fast mirroring sliding windows for GSFA
+    """Tests the equivalence of slow and fast mirroring sliding windows
+    for GSFA.
     """
     x = numx.random.normal(size=(200, 15))
     training_modes = ("window3", "fwindow3")
@@ -229,7 +238,8 @@ def test_equivalence_window3_fwindow3():
 
 
 def test_equivalence_smirror_window3_mirror_window3():
-    """Tests the equivalence of slow and fast mirroring sliding windows for GSFA
+    """Tests the equivalence of slow and fast mirroring sliding windows
+    for GSFA.
     """
     x = numx.random.normal(size=(200, 15))
     training_modes = ("smirror_window3", "mirror_window3")
@@ -248,7 +258,8 @@ def test_equivalence_smirror_window3_mirror_window3():
 
 
 def test_equivalence_smirror_window32_mirror_window32():
-    """Tests the equivalence of slow and fast mirroring sliding windows for GSFA
+    """Tests the equivalence of slow and fast mirroring sliding windows
+    for GSFA.
     """
     x = numx.random.normal(size=(200, 15))
     training_modes = ("smirror_window32", "mirror_window32")

--- a/mdp/test/test_GSFANode.py
+++ b/mdp/test/test_GSFANode.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 from __future__ import division
 
 from ._tools import *
-# import pytest
 from mdp.nodes.gsfa_nodes import graph_delta_values, comp_delta
 
 

--- a/mdp/test/test_GSFANode.py
+++ b/mdp/test/test_GSFANode.py
@@ -1,5 +1,5 @@
 #####################################################################################################################
-# test_GSFANode: Tests for the Graph-Based SFA Node (GSFANode) as defined by the Cuicuilco framework                #
+# test_GSFANode: Tests for the Graph-Based SFA Node (GSFANode)                                                      #
 #                                                                                                                   #
 # By Alberto Escalante. Alberto.Escalante@ini.rub.de                                                                #
 # Ruhr-University Bochum, Institute for Neural Computation, Group of Prof. Dr. Wiskott                              #
@@ -14,7 +14,6 @@ import pytest
 
 from mdp.nodes.gsfa_nodes import graph_delta_values, comp_delta
 
-#TODO: test invalid parameters (training mode, block size, etc)
 
 
 def test_equivalence_SFA_GSFA_regular_mode():

--- a/mdp/test/test_GSFANode.py
+++ b/mdp/test/test_GSFANode.py
@@ -9,12 +9,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from past.utils import old_div
 from ._tools import *
-
-# import numx
 import pytest
-# import mdp
 
 from mdp.nodes.gsfa_nodes import graph_delta_values, comp_delta
 

--- a/mdp/test/test_GSFANode.py
+++ b/mdp/test/test_GSFANode.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
 
-from ._tools import *
+from ._tools import numx, mdp, assert_array_almost_equal, decimal
 from mdp.nodes.gsfa_nodes import graph_delta_values, comp_delta
 
 
@@ -118,7 +118,7 @@ def test_GSFA_zero_mean_unit_variance_graph():
     x = numx.random.normal(size=(200, 15))
     v = numx.ones(200)
     e = {}
-    for i in range(1500):
+    for _ in range(1500):
         n1 = numx.random.randint(200)
         n2 = numx.random.randint(200)
         e[(n1, n2)] = numx.random.normal() + 1.0
@@ -139,7 +139,7 @@ def test_basic_GSFA_edge_dict():
     x = numx.random.normal(size=(200, 15))
     v = numx.ones(200)
     e = {}
-    for i in range(1500):
+    for _ in range(1500):
         n1 = numx.random.randint(200)
         n2 = numx.random.randint(200)
         e[(n1, n2)] = numx.random.normal() + 1.0
@@ -283,7 +283,7 @@ def test_equivalence_update_graph_and_update_graph_old():
     x = numx.random.normal(size=(200, 15))
     v = numx.ones(200)
     e = {}
-    for i in range(1500):
+    for _ in range(1500):
         n1 = numx.random.randint(200)
         n2 = numx.random.randint(200)
         e[(n1, n2)] = numx.random.normal() + 1.0

--- a/mdp/test/test_GSFANode.py
+++ b/mdp/test/test_GSFANode.py
@@ -10,10 +10,8 @@ from __future__ import print_function
 from __future__ import division
 
 from ._tools import *
-import pytest
-
+# import pytest
 from mdp.nodes.gsfa_nodes import graph_delta_values, comp_delta
-
 
 
 def test_equivalence_SFA_GSFA_regular_mode():
@@ -56,9 +54,8 @@ def test_equivalence_SFA_GSFA_regular_mode():
     y = y * signs_gsfa * signs_sfa
     y2 = y2 * signs_gsfa * signs_sfa
 
-    print("y_sfa:", y_sfa, "y:", y)
-    assert (y_sfa - y) == pytest.approx(0.0)
-    assert (y2_sfa - y2) == pytest.approx(0.0)
+    assert_array_almost_equal(y_sfa, y, decimal)
+    assert_array_almost_equal(y2_sfa, y2, decimal)
 
 
 def test_equivalence_GSFA_clustered_and_classification_modes():
@@ -110,7 +107,7 @@ def test_equivalence_GSFA_clustered_and_classification_modes():
     signs_gsfa_clustered = numx.sign(y_clustered[0,:])
     y_clustered = y_clustered * signs_gsfa_clustered * signs_gsfa_classification
 
-    assert (y_clustered - y_classification) == pytest.approx(0.0)
+    assert_array_almost_equal(y_clustered, y_classification, decimal)
 
 
 def test_GSFA_zero_mean_unit_variance_graph():
@@ -128,8 +125,10 @@ def test_GSFA_zero_mean_unit_variance_graph():
     n.stop_training()
 
     y = n.execute(x)
-    assert y.mean(axis=0) == pytest.approx(0.0)
-    assert (y**2).mean(axis=0) == pytest.approx(1.0)
+    y_mean = y.mean(axis=0)
+    y_var = (y**2).mean(axis=0)
+    assert_array_almost_equal(y_mean, numx.zeros(y_mean.shape), decimal)
+    assert_array_almost_equal(y_var, numx.ones(y_var.shape), decimal)
 
 
 def test_basic_GSFA_edge_dict():
@@ -152,14 +151,10 @@ def test_basic_GSFA_edge_dict():
     x2 = numx.random.normal(size=(200, 15))
     y2 = n.execute(x2)
     y2 = y2 - y2.mean(axis=0)  # enforce zero mean
-    y2 /= ((y2**2).mean(axis=0) ** 0.5)  # enforce zero-mean
-    # print("y2 means:", y2.mean(axis=0))
-    # print("y2 std:", (y2**2).mean(axis=0))
+    y2 /= ((y2**2).mean(axis=0) ** 0.5)  # enforce unit variance
 
     delta_values_test_data = graph_delta_values(y2, e)
-    assert (delta_values_training_data < delta_values_test_data).all()
-    # print("Graph delta values of training data", graph_delta_values(y, e))
-    # print("Graph delta values of test data (should be larger than for training)", graph_delta_values(y2, e))
+    assert (delta_values_test_data - delta_values_training_data > -1.5 * 10 ** -decimal).all()
 
 
 def test_equivalence_SFA_GSFA_linear_graph():
@@ -209,12 +204,8 @@ def test_equivalence_SFA_GSFA_linear_graph():
     y = y * signs_gsfa * signs_sfa
     y2 = y2 * signs_gsfa * signs_sfa
 
-    assert (y_sfa - y) == pytest.approx(0.0)
-    assert (y2_sfa - y2) == pytest.approx(0.0)
-
-
-
-
+    assert_array_almost_equal(y_sfa, y, decimal)
+    assert_array_almost_equal(y2_sfa, y2, decimal)
 
 
 # FUTURE: Is it worth it to have so many methods? I guess the mirroring windows are enough, they have constant
@@ -233,11 +224,9 @@ def test_equivalence_window3_fwindow3():
 
         y = n.execute(x)
         delta = comp_delta(y)
-        # print("**Brute Delta Values of mode %s are: " % training_mode, delta)
         delta_values.append(delta)
 
-    # print(delta_values)
-    assert (delta_values[1] - delta_values[0]) == pytest.approx(0.0)
+    assert_array_almost_equal(delta_values[1], delta_values[0], decimal)
 
 
 def test_equivalence_smirror_window3_mirror_window3():
@@ -254,11 +243,9 @@ def test_equivalence_smirror_window3_mirror_window3():
 
         y = n.execute(x)
         delta = comp_delta(y)
-        # print("**Brute Delta Values of mode %s are: " % training_mode, delta)
         delta_values.append(delta)
 
-    # print(delta_values)
-    assert (delta_values[1] - delta_values[0]) == pytest.approx(0.0)
+    assert_array_almost_equal(delta_values[1], delta_values[0], decimal)
 
 
 def test_equivalence_smirror_window32_mirror_window32():
@@ -275,11 +262,9 @@ def test_equivalence_smirror_window32_mirror_window32():
 
         y = n.execute(x)
         delta = comp_delta(y)
-        # print("**Brute Delta Values of mode %s are: " % training_mode, delta)
         delta_values.append(delta)
 
-    # print(delta_values)
-    assert (delta_values[1] - delta_values[0]) == pytest.approx(0.0)
+    assert_array_almost_equal(delta_values[1], delta_values[0], decimal)
 
 
 def test_equivalence_update_graph_and_update_graph_old():
@@ -302,5 +287,4 @@ def test_equivalence_update_graph_and_update_graph_old():
     n2.stop_training()
     y2 = n2.execute(x)
 
-    assert (y - y2) == pytest.approx(0.0)
-
+    assert_array_almost_equal(y, y2, decimal)

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -1,0 +1,198 @@
+#####################################################################################################################
+# test_iGSFANode: Tests for the Information-Preserving Graph-Based SFA Node (iGSFANode) as defined by                #
+#                 the Cuicuilco framework                                                                           #
+#                                                                                                                   #
+# By Alberto-N Escalante-B. Alberto.Escalante@ini.rub.de                                                            #
+# Ruhr-University Bochum, Institute for Neural Computation, Group of Prof. Dr. Wiskott                              #
+#####################################################################################################################
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import division
+import numpy
+import copy
+
+import pytest
+import mdp
+
+
+import cuicuilco.patch_mdp  # Is this necessary???
+from cuicuilco.gsfa_nodes import comp_delta, GSFANode, iGSFANode, SFANode_reduce_output_dim, PCANode_reduce_output_dim
+
+# TODO: rename offsetting_mode -> slow_feature_scaling_method
+#       *test_SFANode_reduce_output_dim (extraction and inverse)
+#       *test_PCANode_reduce_output_dim (extraction and inverse)
+
+#iGSFANode(input_dim=None, output_dim=None, pre_expansion_node_class=None, pre_expansion_out_dim=None,
+#                 expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
+#                 max_length_slow_part=None, slow_feature_scaling_method="sensitivity_based_pure", delta_threshold=1.9999,
+#                 reconstruct_with_sfa=True, **argv)
+
+
+def test_automatic_stop_training():
+    """ Test that verifies that iGSFA automatically calls stop training when trained on single batch mode
+    """
+    x = numpy.random.normal(size=(300, 15))
+
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method=None)
+    n.train(x, train_mode="regular")
+    with pytest.raises(mdp.TrainingFinishedException):
+        n.train(x, train_mode="regular")
+
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="data_dependent")
+    n.train(x, train_mode="regular")
+    with pytest.raises(mdp.TrainingFinishedException):
+        n.train(x, train_mode="regular")
+
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="sensitivity_based")
+    n.train(x, train_mode="regular")
+    with pytest.raises(mdp.TrainingFinishedException):
+        n.train(x, train_mode="regular")
+
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="QR_decomposition")
+    n.train(x, train_mode="regular")
+    with pytest.raises(mdp.TrainingFinishedException):
+        n.train(x, train_mode="regular")
+
+
+def test_no_automatic_stop_training():
+    """ Test that verifies that iGSFA does not call stop training when when multiple-train is used
+    """
+    x = numpy.random.normal(size=(300, 15))
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method=None)
+    n.train(x, train_mode="regular")
+    n.train(x, train_mode="regular")
+    n.stop_training()
+
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method="data_dependent")
+    n.train(x, train_mode="regular")
+    n.train(x, train_mode="regular")
+    n.stop_training()
+
+
+def test_slow_feature_scaling_methods():
+    """ Test that executes each feature scaling method and verifies that (most of them) only change the
+    scale of the slow features in the slow part but do not mix them.
+    """
+    x = numpy.random.normal(size=(300, 15))
+
+    all_slow_feature_scaling_methods = ["QR_decomposition", "sensitivity_based", None, "data_dependent"]
+    num_slow_feature_scaling_methods = len(all_slow_feature_scaling_methods)
+    output_features = []
+    for slow_feature_scaling_method in all_slow_feature_scaling_methods:
+        n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method=slow_feature_scaling_method)
+        n.train(x, train_mode="regular")
+        if n.is_training():
+            n.stop_training()
+        output_features.append(n.execute(x))
+
+
+    size_slow_part = n.sfa_node.output_dim
+    print("size_slow_part:", size_slow_part)
+    for i in range(num_slow_feature_scaling_methods):
+        output_features[i] = output_features[i][:,:size_slow_part]
+    first_sample_y_data_dependent = output_features[num_slow_feature_scaling_methods-1][0]
+    for i in range(1, len(all_slow_feature_scaling_methods)-1):
+        print("checking feature equivalence between", all_slow_feature_scaling_methods[i], "and",
+              all_slow_feature_scaling_methods[num_slow_feature_scaling_methods-1])
+        first_sample_y_i = output_features[i][0]
+        y = output_features[i] * first_sample_y_data_dependent / first_sample_y_i
+        assert (y - output_features[num_slow_feature_scaling_methods-1]) == pytest.approx(0.0)
+
+
+def test_enforce_int_delta_threshold_le_output_dim():
+    x = numpy.random.normal(size=(300, 15))
+    # No automatic stop_training
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method=None, delta_threshold=6)
+    n.train(x, train_mode="regular")
+    n.train(x**3, train_mode="regular")
+    with pytest.raises(Exception):
+        n.stop_training()
+    # Automatic stop_training
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=True, slow_feature_scaling_method=None, delta_threshold=6)
+    with pytest.raises(Exception):
+        n.train(x, train_mode="regular")
+
+
+def test_enforce_int_delta_threshold_le_max_length_slow_part():
+    x = numpy.random.normal(size=(300, 10))
+    # No automatic stop_training
+    n = iGSFANode(output_dim=8, reconstruct_with_sfa=False, slow_feature_scaling_method=None,
+                  max_length_slow_part=5, delta_threshold=6)
+    n.train(x, train_mode="regular")
+    n.train(x**3, train_mode="regular")
+    with pytest.raises(Exception):
+        n.stop_training()
+    # Automatic stop_training
+    n = iGSFANode(output_dim=8, reconstruct_with_sfa=True, slow_feature_scaling_method=None,
+                  max_length_slow_part=5, delta_threshold=6)
+    with pytest.raises(Exception):
+        n.train(x, train_mode="regular")
+
+
+def test_SFANode_reduce_output_dim():
+    x = numpy.random.normal(size=(300, 15))
+    n = mdp.nodes.SFANode(output_dim=10)
+    n.train(x)
+    n.stop_training()
+    y1 = n.execute(x)[:, 0:6]
+
+    n2 = copy.deepcopy(n)
+    SFANode_reduce_output_dim(n2, 6)
+    y2 = n2.execute(x)
+    assert (y2 - y1) == pytest.approx(0.0)
+
+
+def test_PCANode_reduce_output_dim():
+    x = numpy.random.normal(size=(300, 15))
+    n = mdp.nodes.PCANode(output_dim=10)
+    n.train(x)
+    n.stop_training()
+    y1 = n.execute(x)[:, 0:6]
+
+    n2 = copy.deepcopy(n)
+    PCANode_reduce_output_dim(n2, 6)
+    y2 = n2.execute(x)
+    assert (y2 - y1) == pytest.approx(0.0)
+
+
+def test_equivalence_GSFA_iGSFA_for_DT_4_0():
+    """ Test of iGSFA and GSFA when delta_threshold is larger than 4.0
+    """
+    x = numpy.random.normal(size=(300, 15))
+
+    n = iGSFANode(output_dim=5, slow_feature_scaling_method=None, delta_threshold=4.10)
+    n.train(x, train_mode="regular")
+    # n.stop_training() has been automatically called
+
+    y = n.execute(x)
+    deltas_igsfa = comp_delta(y)
+
+    n2 = GSFANode(output_dim=5)
+    n2.train(x, train_mode="regular")
+    n2.stop_training()
+
+    y2 = n2.execute(x)
+    deltas_gsfa = comp_delta(y2)
+    assert (deltas_igsfa - deltas_gsfa) == pytest.approx(0.0)
+
+
+def test_equivalence_GSFA_PCA_for_DT_0():
+    """ Test of iGSFA and PCA when delta_threshold is smaller than 0.0
+    """
+    x = numpy.random.normal(size=(300, 15))
+
+    n = iGSFANode(output_dim=5, slow_feature_scaling_method=None, delta_threshold=0.0)
+    n.train(x, train_mode="regular")
+    # n.stop_training() has been automatically called
+
+    y = n.execute(x)
+    deltas_igsfa = comp_delta(y)
+
+    n2 = mdp.nodes.PCANode(output_dim=5)
+    n2.train(x)
+    n2.stop_training()
+
+    y2 = n2.execute(x)
+    deltas_pca = comp_delta(y2)
+    assert (deltas_igsfa - deltas_pca) == pytest.approx(0.0)

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -1,124 +1,147 @@
-#####################################################################################################################
-# test_iGSFANode: Tests for the Information-Preserving Graph-Based SFA Node (iGSFANode)                             #
-#                                                                                                                   #
-# By Alberto-N Escalante-B. Alberto.Escalante@ini.rub.de                                                            #
-# Ruhr-University Bochum, Institute for Neural Computation, Group of Prof. Dr. Wiskott                              #
-#####################################################################################################################
+###############################################################################
+# test_iGSFANode: Tests for the Information-Preserving Graph-Based            #
+# SFA Node (iGSFANode)                                                        #
+###############################################################################
 
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
-import numpy
 import copy
 
 from ._tools import *
 import mdp
-from mdp.nodes.gsfa_nodes import comp_delta, GSFANode, iGSFANode, SFANode_reduce_output_dim, PCANode_reduce_output_dim
+from mdp.nodes.gsfa_nodes import comp_delta, GSFANode, iGSFANode, \
+    SFANode_reduce_output_dim, PCANode_reduce_output_dim
 
 
 def test_automatic_stop_training():
-    """ Test that verifies that iGSFA automatically calls stop training when trained on single batch mode
+    """ Test that verifies that iGSFA automatically calls stop training when
+    trained on single batch mode.
     """
-    x = numpy.random.normal(size=(300, 15))
+    x = numx.random.normal(size=(300, 15))
 
-    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method=None)
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True,
+                  slow_feature_scaling_method=None)
     n.train(x, train_mode="regular")
     with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
-    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="data_dependent")
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True,
+                  slow_feature_scaling_method="data_dependent")
     n.train(x, train_mode="regular")
     with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
-    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="sensitivity_based")
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True,
+                  slow_feature_scaling_method="sensitivity_based")
     n.train(x, train_mode="regular")
     with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
-    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="QR_decomposition")
+    n = iGSFANode(output_dim=15, reconstruct_with_sfa=True,
+                  slow_feature_scaling_method="QR_decomposition")
     n.train(x, train_mode="regular")
     with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
 
 def test_no_automatic_stop_training():
-    """ Test that verifies that iGSFA does not call stop training when when multiple-train is used
+    """ Test that verifies that iGSFA does not call stop training when
+    multiple-train is used.
     """
-    x = numpy.random.normal(size=(300, 15))
-    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method=None)
+    x = numx.random.normal(size=(300, 15))
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False,
+                  slow_feature_scaling_method=None)
     n.train(x, train_mode="regular")
     n.train(x, train_mode="regular")
     n.stop_training()
 
-    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method="data_dependent")
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False,
+                  slow_feature_scaling_method="data_dependent")
     n.train(x, train_mode="regular")
     n.train(x, train_mode="regular")
     n.stop_training()
 
 
 def test_slow_feature_scaling_methods():
-    """ Test that executes each feature scaling method and verifies that (most of them) only change the
-    scale of the slow features in the slow part but do not mix them.
+    """ Test that executes each feature scaling method and verifies that
+    (most of them) only change the scale of the slow features in the slow
+    part but do not mix them.
     """
-    x = numpy.random.normal(size=(300, 15))
+    x = numx.random.normal(size=(300, 15))
 
-    all_slow_feature_scaling_methods = ["QR_decomposition", "sensitivity_based", None, "data_dependent"]
+    all_slow_feature_scaling_methods = ["QR_decomposition",
+                                        "sensitivity_based",
+                                        None,
+                                        "data_dependent"]
     num_slow_feature_scaling_methods = len(all_slow_feature_scaling_methods)
     output_features = []
     for slow_feature_scaling_method in all_slow_feature_scaling_methods:
-        n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method=slow_feature_scaling_method)
+        n = iGSFANode(output_dim=15, reconstruct_with_sfa=True,
+                      slow_feature_scaling_method=slow_feature_scaling_method)
         n.train(x, train_mode="regular")
         if n.is_training():
             n.stop_training()
         output_features.append(n.execute(x))
 
-
-    size_slow_part = n.sfa_node.output_dim
+    size_slow_part = 15
     print("size_slow_part:", size_slow_part)
     for i in range(num_slow_feature_scaling_methods):
-        output_features[i] = output_features[i][:,:size_slow_part]
-    first_sample_y_data_dependent = output_features[num_slow_feature_scaling_methods-1][0]
+        output_features[i] = output_features[i][:, :size_slow_part]
+    first_sample_y_data_dependent = \
+        output_features[num_slow_feature_scaling_methods-1][0]
     for i in range(1, len(all_slow_feature_scaling_methods)-1):
-        print("checking feature equivalence between", all_slow_feature_scaling_methods[i], "and",
+        print("checking feature equivalence between",
+              all_slow_feature_scaling_methods[i], "and",
               all_slow_feature_scaling_methods[num_slow_feature_scaling_methods-1])
         first_sample_y_i = output_features[i][0]
-        y = output_features[i] * first_sample_y_data_dependent / first_sample_y_i
-        assert_array_almost_equal(y, output_features[num_slow_feature_scaling_methods-1], decimal)
+        y = output_features[i] \
+            * first_sample_y_data_dependent / first_sample_y_i
+        assert_array_almost_equal(y,
+                                  output_features[num_slow_feature_scaling_methods-1],
+                                  decimal)
 
 
 def test_enforce_int_delta_threshold_le_output_dim():
-    x = numpy.random.normal(size=(300, 15))
-    # No automatic stop_training. Since delta_threshold > output_dim this should rise an exception
-    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method=None, delta_threshold=6)
+    x = numx.random.normal(size=(300, 15))
+    # No automatic stop_training. Since delta_threshold > output_dim this
+    # should rise an exception
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=False,
+                  slow_feature_scaling_method=None, delta_threshold=6)
     n.train(x, train_mode="regular")
     n.train(x**3, train_mode="regular")
     with py.test.raises(Exception):
         n.stop_training()
-    # Automatic stop_training. Since delta_threshold > output_dim this should rise an exception
-    n = iGSFANode(output_dim=5, reconstruct_with_sfa=True, slow_feature_scaling_method=None, delta_threshold=6)
+    # Automatic stop_training. Since delta_threshold > output_dim this
+    # should rise an exception
+    n = iGSFANode(output_dim=5, reconstruct_with_sfa=True,
+                  slow_feature_scaling_method=None, delta_threshold=6)
     with py.test.raises(Exception):
         n.train(x, train_mode="regular")
 
 
 def test_enforce_int_delta_threshold_le_max_length_slow_part():
-    x = numpy.random.normal(size=(300, 10))
-    # No automatic stop_training. Since delta_threshold > max_length_slow_part this should rise an exception
-    n = iGSFANode(output_dim=8, reconstruct_with_sfa=False, slow_feature_scaling_method=None,
+    x = numx.random.normal(size=(300, 10))
+    # No automatic stop_training. Since delta_threshold > max_length_slow_part,
+    #  this should rise an exception
+    n = iGSFANode(output_dim=8, reconstruct_with_sfa=False,
+                  slow_feature_scaling_method=None,
                   max_length_slow_part=5, delta_threshold=6)
     n.train(x, train_mode="regular")
     n.train(x**3, train_mode="regular")
     with py.test.raises(Exception):
         n.stop_training()
-    # Automatic stop_training. Since delta_threshold > max_length_slow_part this should rise an exception
-    n = iGSFANode(output_dim=8, reconstruct_with_sfa=True, slow_feature_scaling_method=None,
+    # Automatic stop_training. Since delta_threshold > max_length_slow_part,
+    #  this should rise an exception
+    n = iGSFANode(output_dim=8, reconstruct_with_sfa=True,
+                  slow_feature_scaling_method=None,
                   max_length_slow_part=5, delta_threshold=6)
     with py.test.raises(Exception):
         n.train(x, train_mode="regular")
 
 
 def test_SFANode_reduce_output_dim():
-    x = numpy.random.normal(size=(300, 15))
+    x = numx.random.normal(size=(300, 15))
     n = mdp.nodes.SFANode(output_dim=10)
     n.train(x)
     n.stop_training()
@@ -131,7 +154,7 @@ def test_SFANode_reduce_output_dim():
 
 
 def test_PCANode_reduce_output_dim():
-    x = numpy.random.normal(size=(300, 15))
+    x = numx.random.normal(size=(300, 15))
     n = mdp.nodes.PCANode(output_dim=10)
     n.train(x)
     n.stop_training()
@@ -146,11 +169,12 @@ def test_PCANode_reduce_output_dim():
 def test_equivalence_GSFA_iGSFA_for_DT_4_0():
     """ Test of iGSFA and GSFA when delta_threshold is larger than 4.0
     """
-    x = numpy.random.normal(size=(300, 15))
+    x = numx.random.normal(size=(300, 15))
 
-    n = iGSFANode(output_dim=5, slow_feature_scaling_method=None, delta_threshold=4.10)
+    n = iGSFANode(output_dim=5, slow_feature_scaling_method=None,
+                  delta_threshold=4.10)
     n.train(x, train_mode="regular")
-    # n.stop_training() has been automatically called
+    # Note: n.stop_training() has been automatically called
 
     y = n.execute(x)
     deltas_igsfa = comp_delta(y)
@@ -168,9 +192,10 @@ def test_equivalence_GSFA_iGSFA_for_DT_4_0():
 def test_equivalence_GSFA_PCA_for_DT_0():
     """ Test of iGSFA and PCA when delta_threshold is smaller than 0.0
     """
-    x = numpy.random.normal(size=(300, 15))
+    x = numx.random.normal(size=(300, 15))
 
-    n = iGSFANode(output_dim=5, slow_feature_scaling_method=None, delta_threshold=0.0)
+    n = iGSFANode(output_dim=5, slow_feature_scaling_method=None,
+                  delta_threshold=0.0)
     n.train(x, train_mode="regular")
     # n.stop_training() has been automatically called
 

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -12,16 +12,8 @@ import numpy
 import copy
 
 from ._tools import *
-import pytest
 import mdp
-
 from mdp.nodes.gsfa_nodes import comp_delta, GSFANode, iGSFANode, SFANode_reduce_output_dim, PCANode_reduce_output_dim
-
-
-#iGSFANode(input_dim=None, output_dim=None, pre_expansion_node_class=None, pre_expansion_out_dim=None,
-#          expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
-#          max_length_slow_part=None, slow_feature_scaling_method="sensitivity_based_pure", delta_threshold=1.9999,
-#          reconstruct_with_sfa=True, **argv)
 
 
 def test_automatic_stop_training():
@@ -31,22 +23,22 @@ def test_automatic_stop_training():
 
     n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method=None)
     n.train(x, train_mode="regular")
-    with pytest.raises(mdp.TrainingFinishedException):
+    with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
     n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="data_dependent")
     n.train(x, train_mode="regular")
-    with pytest.raises(mdp.TrainingFinishedException):
+    with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
     n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="sensitivity_based")
     n.train(x, train_mode="regular")
-    with pytest.raises(mdp.TrainingFinishedException):
+    with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
     n = iGSFANode(output_dim=15, reconstruct_with_sfa=True, slow_feature_scaling_method="QR_decomposition")
     n.train(x, train_mode="regular")
-    with pytest.raises(mdp.TrainingFinishedException):
+    with py.test.raises(mdp.TrainingFinishedException):
         n.train(x, train_mode="regular")
 
 
@@ -92,7 +84,7 @@ def test_slow_feature_scaling_methods():
               all_slow_feature_scaling_methods[num_slow_feature_scaling_methods-1])
         first_sample_y_i = output_features[i][0]
         y = output_features[i] * first_sample_y_data_dependent / first_sample_y_i
-        assert (y - output_features[num_slow_feature_scaling_methods-1]) == pytest.approx(0.0)
+        assert_array_almost_equal(y, output_features[num_slow_feature_scaling_methods-1], decimal)
 
 
 def test_enforce_int_delta_threshold_le_output_dim():
@@ -101,11 +93,11 @@ def test_enforce_int_delta_threshold_le_output_dim():
     n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method=None, delta_threshold=6)
     n.train(x, train_mode="regular")
     n.train(x**3, train_mode="regular")
-    with pytest.raises(Exception):
+    with py.test.raises(Exception):
         n.stop_training()
     # Automatic stop_training. Since delta_threshold > output_dim this should rise an exception
     n = iGSFANode(output_dim=5, reconstruct_with_sfa=True, slow_feature_scaling_method=None, delta_threshold=6)
-    with pytest.raises(Exception):
+    with py.test.raises(Exception):
         n.train(x, train_mode="regular")
 
 
@@ -116,12 +108,12 @@ def test_enforce_int_delta_threshold_le_max_length_slow_part():
                   max_length_slow_part=5, delta_threshold=6)
     n.train(x, train_mode="regular")
     n.train(x**3, train_mode="regular")
-    with pytest.raises(Exception):
+    with py.test.raises(Exception):
         n.stop_training()
     # Automatic stop_training. Since delta_threshold > max_length_slow_part this should rise an exception
     n = iGSFANode(output_dim=8, reconstruct_with_sfa=True, slow_feature_scaling_method=None,
                   max_length_slow_part=5, delta_threshold=6)
-    with pytest.raises(Exception):
+    with py.test.raises(Exception):
         n.train(x, train_mode="regular")
 
 
@@ -135,7 +127,7 @@ def test_SFANode_reduce_output_dim():
     n2 = copy.deepcopy(n)
     SFANode_reduce_output_dim(n2, 6)
     y2 = n2.execute(x)
-    assert (y2 - y1) == pytest.approx(0.0)
+    assert_array_almost_equal(y2, y1, decimal)
 
 
 def test_PCANode_reduce_output_dim():
@@ -148,7 +140,7 @@ def test_PCANode_reduce_output_dim():
     n2 = copy.deepcopy(n)
     PCANode_reduce_output_dim(n2, 6)
     y2 = n2.execute(x)
-    assert (y2 - y1) == pytest.approx(0.0)
+    assert_array_almost_equal(y2, y1, decimal)
 
 
 def test_equivalence_GSFA_iGSFA_for_DT_4_0():
@@ -169,7 +161,8 @@ def test_equivalence_GSFA_iGSFA_for_DT_4_0():
 
     y2 = n2.execute(x)
     deltas_gsfa = comp_delta(y2)
-    assert (deltas_igsfa - deltas_gsfa) == pytest.approx(0.0)
+
+    assert_array_almost_equal(deltas_igsfa, deltas_gsfa, decimal)
 
 
 def test_equivalence_GSFA_PCA_for_DT_0():
@@ -190,4 +183,4 @@ def test_equivalence_GSFA_PCA_for_DT_0():
 
     y2 = n2.execute(x)
     deltas_pca = comp_delta(y2)
-    assert (deltas_igsfa - deltas_pca) == pytest.approx(0.0)
+    assert_array_almost_equal(deltas_igsfa, deltas_pca, decimal)

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -1,6 +1,5 @@
 #####################################################################################################################
-# test_iGSFANode: Tests for the Information-Preserving Graph-Based SFA Node (iGSFANode) as defined by                #
-#                 the Cuicuilco framework                                                                           #
+# test_iGSFANode: Tests for the Information-Preserving Graph-Based SFA Node (iGSFANode)                             #
 #                                                                                                                   #
 # By Alberto-N Escalante-B. Alberto.Escalante@ini.rub.de                                                            #
 # Ruhr-University Bochum, Institute for Neural Computation, Group of Prof. Dr. Wiskott                              #

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -12,16 +12,15 @@ from __future__ import division
 import numpy
 import copy
 
+from ._tools import *
 import pytest
 import mdp
 
+# import cuicuilco.patch_mdp
+from mdp.nodes.gsfa_nodes import comp_delta, GSFANode, iGSFANode, SFANode_reduce_output_dim, PCANode_reduce_output_dim
 
-import cuicuilco.patch_mdp  # Is this necessary???
-from cuicuilco.gsfa_nodes import comp_delta, GSFANode, iGSFANode, SFANode_reduce_output_dim, PCANode_reduce_output_dim
-
-# TODO: rename offsetting_mode -> slow_feature_scaling_method
-#       *test_SFANode_reduce_output_dim (extraction and inverse)
-#       *test_PCANode_reduce_output_dim (extraction and inverse)
+# *test_SFANode_reduce_output_dim (extraction and inverse)
+# *test_PCANode_reduce_output_dim (extraction and inverse)
 
 #iGSFANode(input_dim=None, output_dim=None, pre_expansion_node_class=None, pre_expansion_out_dim=None,
 #                 expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -8,10 +8,9 @@ from __future__ import print_function
 from __future__ import division
 import copy
 
-from ._tools import *
-import mdp
 from mdp.nodes.gsfa_nodes import comp_delta, GSFANode, iGSFANode, \
     SFANode_reduce_output_dim, PCANode_reduce_output_dim
+from ._tools import numx, mdp, assert_array_almost_equal, decimal, py
 
 
 def test_automatic_stop_training():

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -18,13 +18,11 @@ import mdp
 
 from mdp.nodes.gsfa_nodes import comp_delta, GSFANode, iGSFANode, SFANode_reduce_output_dim, PCANode_reduce_output_dim
 
-# *test_SFANode_reduce_output_dim (extraction and inverse)
-# *test_PCANode_reduce_output_dim (extraction and inverse)
 
 #iGSFANode(input_dim=None, output_dim=None, pre_expansion_node_class=None, pre_expansion_out_dim=None,
-#                 expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
-#                 max_length_slow_part=None, slow_feature_scaling_method="sensitivity_based_pure", delta_threshold=1.9999,
-#                 reconstruct_with_sfa=True, **argv)
+#          expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
+#          max_length_slow_part=None, slow_feature_scaling_method="sensitivity_based_pure", delta_threshold=1.9999,
+#          reconstruct_with_sfa=True, **argv)
 
 
 def test_automatic_stop_training():
@@ -98,32 +96,30 @@ def test_slow_feature_scaling_methods():
         assert (y - output_features[num_slow_feature_scaling_methods-1]) == pytest.approx(0.0)
 
 
-#TODO: write this test
 def test_enforce_int_delta_threshold_le_output_dim():
     x = numpy.random.normal(size=(300, 15))
-    # No automatic stop_training
+    # No automatic stop_training. Since delta_threshold > output_dim this should rise an exception
     n = iGSFANode(output_dim=5, reconstruct_with_sfa=False, slow_feature_scaling_method=None, delta_threshold=6)
     n.train(x, train_mode="regular")
     n.train(x**3, train_mode="regular")
     with pytest.raises(Exception):
         n.stop_training()
-    # Automatic stop_training
+    # Automatic stop_training. Since delta_threshold > output_dim this should rise an exception
     n = iGSFANode(output_dim=5, reconstruct_with_sfa=True, slow_feature_scaling_method=None, delta_threshold=6)
     with pytest.raises(Exception):
         n.train(x, train_mode="regular")
 
 
-#TODO: write this test
 def test_enforce_int_delta_threshold_le_max_length_slow_part():
     x = numpy.random.normal(size=(300, 10))
-    # No automatic stop_training
+    # No automatic stop_training. Since delta_threshold > max_length_slow_part this should rise an exception
     n = iGSFANode(output_dim=8, reconstruct_with_sfa=False, slow_feature_scaling_method=None,
                   max_length_slow_part=5, delta_threshold=6)
     n.train(x, train_mode="regular")
     n.train(x**3, train_mode="regular")
     with pytest.raises(Exception):
         n.stop_training()
-    # Automatic stop_training
+    # Automatic stop_training. Since delta_threshold > max_length_slow_part this should rise an exception
     n = iGSFANode(output_dim=8, reconstruct_with_sfa=True, slow_feature_scaling_method=None,
                   max_length_slow_part=5, delta_threshold=6)
     with pytest.raises(Exception):

--- a/mdp/test/test_iGSFANode.py
+++ b/mdp/test/test_iGSFANode.py
@@ -16,7 +16,6 @@ from ._tools import *
 import pytest
 import mdp
 
-# import cuicuilco.patch_mdp
 from mdp.nodes.gsfa_nodes import comp_delta, GSFANode, iGSFANode, SFANode_reduce_output_dim, PCANode_reduce_output_dim
 
 # *test_SFANode_reduce_output_dim (extraction and inverse)
@@ -99,6 +98,7 @@ def test_slow_feature_scaling_methods():
         assert (y - output_features[num_slow_feature_scaling_methods-1]) == pytest.approx(0.0)
 
 
+#TODO: write this test
 def test_enforce_int_delta_threshold_le_output_dim():
     x = numpy.random.normal(size=(300, 15))
     # No automatic stop_training
@@ -113,6 +113,7 @@ def test_enforce_int_delta_threshold_le_output_dim():
         n.train(x, train_mode="regular")
 
 
+#TODO: write this test
 def test_enforce_int_delta_threshold_le_max_length_slow_part():
     x = numpy.random.normal(size=(300, 10))
     # No automatic stop_training

--- a/mdp/test/test_nodes_generic.py
+++ b/mdp/test/test_nodes_generic.py
@@ -282,6 +282,9 @@ def NeuralGasNode_inp_arg_gen():
 def LinearRegressionNode_inp_arg_gen():
     return uniform(size=(1000, 5))
 
+def iGSFANode_inp_arg_gen():
+    return uniform(size=(1000, 4)) * 0.01  #
+
 def _rand_1d(x):
     return uniform(size=(x.shape[0],))
 
@@ -345,6 +348,13 @@ NODES = [
          init_args=[(nodes.PolynomialExpansionNode, (1,), {}),
                     (nodes.PolynomialExpansionNode, (1,), {}),
                     True]),
+    dict(klass='iGSFANode',
+         init_args=[None, None, None, None, None, None, None, 0.5, False, False],
+#         """pre_expansion_node_class=None, pre_expansion_out_dim=None,
+#                 expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
+#                 max_length_slow_part=None, slow_feature_scaling_method=None, delta_threshold=1.999,
+#                 reconstruct_with_sfa=False, verbose=False, input_dim=None, output_dim=None, **argv"""
+         inp_arg_gen=iGSFANode_inp_arg_gen),
     dict(klass='LLENode',
          inp_arg_gen=_contrib_get_random_mix,
          init_args=[3, 0.001, True]),
@@ -361,7 +371,6 @@ NODES = [
          inp_arg_gen=CCIPCANode_inp_arg_gen),
     dict(klass='IncSFANode',
          inp_arg_gen=CCIPCANode_inp_arg_gen),
-
     dict(klass='PerceptronClassifier',
          sup_arg_gen=_rand_classification_labels_array),
     dict(klass='SimpleMarkovClassifier',

--- a/mdp/test/test_nodes_generic.py
+++ b/mdp/test/test_nodes_generic.py
@@ -283,7 +283,7 @@ def LinearRegressionNode_inp_arg_gen():
     return uniform(size=(1000, 5))
 
 def iGSFANode_inp_arg_gen():
-    return uniform(size=(1000, 4)) * 0.01  #
+    return uniform(size=(1000, 4)) * 0.01
 
 def _rand_1d(x):
     return uniform(size=(x.shape[0],))
@@ -350,10 +350,6 @@ NODES = [
                     True]),
     dict(klass='iGSFANode',
          init_args=[None, None, None, None, None, None, None, 0.5, False, False],
-#         """pre_expansion_node_class=None, pre_expansion_out_dim=None,
-#                 expansion_funcs=None, expansion_output_dim=None, expansion_starting_point=None,
-#                 max_length_slow_part=None, slow_feature_scaling_method=None, delta_threshold=1.999,
-#                 reconstruct_with_sfa=False, verbose=False, input_dim=None, output_dim=None, **argv"""
          inp_arg_gen=iGSFANode_inp_arg_gen),
     dict(klass='LLENode',
          inp_arg_gen=_contrib_get_random_mix,


### PR DESCRIPTION
Dear MDP developers and enthusiasts,

I am glad to share the following code for your consideration and possible inclusion in the MDP-toolkit. It consists of two new nodes that implement graph-based SFA (GSFA) and information-preserving GSFA (iGSFA). 

GSFA is a generalization of SFA that has been designed for supervised dimensionality reduction and facilitates the solution of regression and classification problems, whereas iGSFA enhances the feature representation of (G)SFA. The improved feature representation is particularly useful when the algorithm is applied hierarchically by means of hierarchical iGSFA (HiGSFA) networks. 

Why should we include these algorithms? HiGSFA has consistently yielded slower top level features and better generalization than HSFA. For example, for age estimation from facial images (MORPH-II database) HiGSFA yields a mean absolute error of 3.41 years, which was state-of-the-art accuracy for some months. Also gender and ethnicity estimation were improved.
On a more standard database, MNIST, HiGSFA yields a classification error of 0.67% (preprocessing: 2-pixel image shifts, hyperparameters computed on hold out validation sets). As far as I know this is better than previous versions of SFA and HSFA. Face localization and detection also benefit from HiGSFA. 
Even unsupervised learning applications benefit from the new extensions. An experiment where the input data is the simulated view of a rat moving inside a box shows that HiSFA (a special case of HiGSFA) clearly improves top level feature slowness compared to HSFA. For this experiment is HiSFA about 8 times more data/sample efficient than HSFA.

I will highly appreciate all your feedback regarding the code, style, tests, and documentation. Currently all test pass using pytest 3.5.0 but some fail using 3.4.0 and older versions. What is the oldest version of pytest that we should support? 

Thank you very much for your time and consideration,

Alberto Escalante
PS 1. HiGSFA has been explained in this manuscript: https://arxiv.org/abs/1601.03945. However, this version has become obsolete by now, if you would like to get an updated version just write me a short e-mail.

PS 2. pytest 3.5 gives hundreds of warnings “Metafunc.addcall is deprecated and scheduled to be removed in pytest 4.0. Please use Metafunc.parametrize instead.”, perhaps we should consider updating this part of the tests.