### PR TITLE
swapped out deprecated metafunc.addcall method in pytest

### DIFF
--- a/mdp/test/test_namespace_fixups.py
+++ b/mdp/test/test_namespace_fixups.py
@@ -1,6 +1,7 @@
 import sys
 from ._tools import *
 
+
 def _list_module(module):
     try:
         names = module.__all__
@@ -17,6 +18,7 @@ def _list_module(module):
         if hasattr(item, '__module__'):
             yield modname, name, item
 
+
 MODULES = ['mdp',
            'mdp.nodes',
            'mdp.hinet',
@@ -25,12 +27,18 @@ MODULES = ['mdp',
            'mdp.utils',
            ]
 
+
 def pytest_generate_tests(metafunc):
     generate_calls(MODULES, metafunc)
 
+
 def generate_calls(modules, metafunc):
-    for module in modules:
-        metafunc.addcall(funcargs=dict(parentname=module), id=module)
+    # make list of different argument values
+    argvalues = [module for module in modules]
+    # only one argument name
+    metafunc.parametrize(argnames='parentname', argvalues=argvalues,
+                         ids=argvalues)
+
 
 def test_exports(parentname):
     rootname = parentname.split('.')[-1]
@@ -39,5 +47,5 @@ def test_exports(parentname):
         parts = modname.split('.')
         assert (parts[0] != rootname or
                 modname == parentname), \
-                '%s.%s.__module_ == %s != %s' % (
-                    parentname, itemname, item.__module__, parentname)
+            '%s.%s.__module_ == %s != %s' % (
+                parentname, itemname, item.__module__, parentname)

--- a/mdp/test/test_nodes_generic.py
+++ b/mdp/test/test_nodes_generic.py
@@ -9,42 +9,53 @@ from ._tools import *
 
 uniform = numx_rand.random
 
+
 def _rand_labels(x):
     return numx_rand.randint(0, 2, size=(x.shape[0],))
+
 
 def _rand_labels_array(x):
     return numx_rand.randint(0, 2, size=(x.shape[0], 1))
 
+
 def _rand_classification_labels_array(x):
     labels = numx_rand.randint(0, 2, size=(x.shape[0],))
-    labels[labels==0] = -1
+    labels[labels == 0] = -1
     return labels
+
 
 def _dumb_quadratic_expansion(x):
     dim_x = x.shape[1]
-    return numx.asarray([(x[i].reshape(dim_x,1) *
-                          x[i].reshape(1,dim_x)).flatten()
+    return numx.asarray([(x[i].reshape(dim_x, 1) *
+                          x[i].reshape(1, dim_x)).flatten()
                          for i in range(len(x))])
+
 
 def _rand_array_halfdim(x):
     return uniform(size=(x.shape[0], x.shape[1]//2))
 
+
 class Iter(object):
     pass
 
+
 def _rand_array_single_rows():
-    x = uniform((500,4))
+    x = uniform((500, 4))
+
     class _Iter(Iter):
         def __iter__(self):
             for row in range(x.shape[0]):
-                yield x[numx.newaxis,row,:]
+                yield x[numx.newaxis, row, :]
     return _Iter()
+
 
 def _contrib_get_random_mix():
     return get_random_mix(type='d', mat_dim=(100, 3))[2]
 
+
 def _positive_get_random_mix():
     return abs(get_random_mix()[2])
+
 
 def _train_if_necessary(inp, node, sup_arg_gen):
     if node.is_trainable():
@@ -64,6 +75,7 @@ def _train_if_necessary(inp, node, sup_arg_gen):
             else:
                 break
 
+
 def _stop_training_or_execute(node, inp):
     if node.is_trainable():
         node.stop_training()
@@ -74,8 +86,10 @@ def _stop_training_or_execute(node, inp):
         else:
             node.execute(inp)
 
+
 def pytest_generate_tests(metafunc):
     generic_test_factory(NODES, metafunc)
+
 
 def generic_test_factory(big_nodes, metafunc):
     """Generator creating a test for each of the nodes
@@ -114,15 +128,12 @@ def generic_test_factory(big_nodes, metafunc):
       The return value is unpacked and used as additional arguments to
       `execute`.
     """
+    ids = []
+    argvalues = []
     for nodetype in big_nodes:
+
         if not isinstance(nodetype, dict):
             nodetype = dict(klass=nodetype)
-        funcargs = dict(
-            init_args=(),
-            inp_arg_gen=lambda: get_random_mix(type='d')[2],
-            sup_arg_gen=None,
-            execute_arg_gen=None)
-        funcargs.update(nodetype)
 
         if hasattr(metafunc.function, 'only_if_node_condition'):
             # A TypeError can be thrown by the condition checking
@@ -134,8 +145,30 @@ def generic_test_factory(big_nodes, metafunc):
             except TypeError:
                 continue
 
-        theid = nodetype['klass'].__name__
-        metafunc.addcall(funcargs, id=theid)
+        argv = [(), lambda: get_random_mix(type='d')
+                [2], None, None, None]
+
+        # add whatever is in nodetype to the argumentlist
+        for key in nodetype:
+            if key == 'init_args':
+                argv[0] = nodetype[key]
+            elif key == 'inp_arg_gen':
+                argv[1] = nodetype[key]
+            elif key == 'sup_arg_gen':
+                argv[2] = nodetype[key]
+            elif key == 'execute_arg_gen':
+                argv[3] = nodetype[key]
+            elif key == 'klass':
+                argv[4] = nodetype[key]
+
+        # make list with different inputs
+        argvalues.append(tuple(argv))
+        ids.append(nodetype['klass'].__name__)
+
+    # argnames are the same
+    argnames = 'init_args,inp_arg_gen,sup_arg_gen,execute_arg_gen,klass'
+    metafunc.parametrize(argnames=argnames, argvalues=argvalues, ids=ids)
+
 
 def only_if_node(condition):
     """Execute the test only if condition(nodetype) is True.
@@ -147,9 +180,11 @@ def only_if_node(condition):
         return func
     return f
 
+
 def call_init_args(init_args):
     return [item() if hasattr(item, '__call__') else item
             for item in init_args]
+
 
 def test_dtype_consistency(klass, init_args, inp_arg_gen,
                            sup_arg_gen, execute_arg_gen):
@@ -198,7 +233,7 @@ def test_outputdim_consistency(klass, init_args, inp_arg_gen,
     # check if the node output dimension can be set or must be determined
     # by the node
     if (not issubclass(klass, PreserveDimNode) and
-        'output_dim' in inspect.getargspec(klass.__init__)[0]):
+            'output_dim' in inspect.getargspec(klass.__init__)[0]):
         # case 1: output dim set in the constructor
         node = klass(output_dim=output_dim, *args)
         _test(node)
@@ -215,7 +250,7 @@ def test_outputdim_consistency(klass, init_args, inp_arg_gen,
             # raises an appropriate error
             # case 1: both in the constructor
             py.test.raises(InconsistentDimException,
-                   'klass(input_dim=inp.shape[1], output_dim=output_dim, *args)')
+                           'klass(input_dim=inp.shape[1], output_dim=output_dim, *args)')
             # case 2: first input_dim, then output_dim
             node = klass(input_dim=inp.shape[1], *args)
             py.test.raises(InconsistentDimException,
@@ -238,6 +273,7 @@ def test_outputdim_consistency(klass, init_args, inp_arg_gen,
 
         assert out.shape[1] == node.output_dim
 
+
 def test_dimdtypeset(klass, init_args, inp_arg_gen,
                      sup_arg_gen, execute_arg_gen):
     init_args = call_init_args(init_args)
@@ -248,6 +284,7 @@ def test_dimdtypeset(klass, init_args, inp_arg_gen,
     assert node.output_dim is not None
     assert node.dtype is not None
     assert node.input_dim is not None
+
 
 @only_if_node(lambda nodetype: nodetype.is_invertible())
 def test_inverse(klass, init_args, inp_arg_gen,
@@ -268,25 +305,31 @@ def test_inverse(klass, init_args, inp_arg_gen,
     assert_array_almost_equal_diff(rec, inp, decimal-3)
     assert rec.dtype == dtype
 
+
 def SFA2Node_inp_arg_gen():
-    freqs = [2*numx.pi*100.,2*numx.pi*200.]
-    t =  numx.linspace(0, 1, num=1000)
+    freqs = [2*numx.pi*100., 2*numx.pi*200.]
+    t = numx.linspace(0, 1, num=1000)
     mat = numx.array([numx.sin(freqs[0]*t),
                       numx.sin(freqs[1]*t)]).T
     inp = mat.astype('d')
     return inp
 
+
 def NeuralGasNode_inp_arg_gen():
-    return numx.asarray([[2.,0,0],[-2,0,0],[0,0,0]])
+    return numx.asarray([[2., 0, 0], [-2, 0, 0], [0, 0, 0]])
+
 
 def LinearRegressionNode_inp_arg_gen():
     return uniform(size=(1000, 5))
 
+
 def iGSFANode_inp_arg_gen():
     return uniform(size=(1000, 4)) * 0.01
 
+
 def _rand_1d(x):
     return uniform(size=(x.shape[0],))
+
 
 def CCIPCANode_inp_arg_gen():
     line_x = numx.zeros((1000, 2), "d")
@@ -302,7 +345,7 @@ def CCIPCANode_inp_arg_gen():
 
 NODES = [
     dict(klass='NeuralGasNode',
-         init_args=[3,NeuralGasNode_inp_arg_gen()],
+         init_args=[3, NeuralGasNode_inp_arg_gen()],
          inp_arg_gen=NeuralGasNode_inp_arg_gen),
     dict(klass='SFA2Node',
          inp_arg_gen=SFA2Node_inp_arg_gen),
@@ -338,7 +381,7 @@ NODES = [
     dict(klass='LinearRegressionNode',
          sup_arg_gen=_rand_array_halfdim),
     dict(klass='Convolution2DNode',
-         init_args=[mdp.numx.array([[[1.]]]), (5,1)]),
+         init_args=[mdp.numx.array([[[1.]]]), (5, 1)]),
     dict(klass='JADENode',
          inp_arg_gen=_contrib_get_random_mix),
     dict(klass='NIPALSNode',
@@ -349,7 +392,8 @@ NODES = [
                     (nodes.PolynomialExpansionNode, (1,), {}),
                     True]),
     dict(klass='iGSFANode',
-         init_args=[None, None, None, None, None, None, None, 0.5, False, False],
+         init_args=[None, None, None, None, None,
+                    None, None, 0.5, False, False],
          inp_arg_gen=iGSFANode_inp_arg_gen),
     dict(klass='LLENode',
          inp_arg_gen=_contrib_get_random_mix,
@@ -372,23 +416,23 @@ NODES = [
     dict(klass='SimpleMarkovClassifier',
          sup_arg_gen=_rand_classification_labels_array),
     dict(klass='ShogunSVMClassifier',
-        sup_arg_gen=_rand_labels_array,
-        init_args=["libsvmmulticlass", (), None, "GaussianKernel"]),
+         sup_arg_gen=_rand_labels_array,
+         init_args=["libsvmmulticlass", (), None, "GaussianKernel"]),
     dict(klass='LibSVMClassifier',
-        sup_arg_gen=_rand_labels_array,
-        init_args=["LINEAR","C_SVC"]),
+         sup_arg_gen=_rand_labels_array,
+         init_args=["LINEAR", "C_SVC"]),
     dict(klass='MultinomialNBScikitsLearnNode',
          inp_arg_gen=_positive_get_random_mix,
          sup_arg_gen=_rand_labels),
     dict(klass='NeighborsScikitsLearnNode',
-        sup_arg_gen=_rand_1d),
-    ]
+         sup_arg_gen=_rand_1d),
+]
 
 # LabelSpreadingScikitsLearnNode is broken in sklearn version 0.11
 # It works fine in version 0.12
-EXCLUDE_NODES = ['ICANode', 'LabelSpreadingScikitsLearnNode', 
-        'OutputCodeClassifierScikitsLearnNode', 'OneVsOneClassifierScikitsLearnNode',
-        'OneVsRestClassifierScikitsLearnNode', 'VotingClassifierScikitsLearnNode']
+EXCLUDE_NODES = ['ICANode', 'LabelSpreadingScikitsLearnNode',
+                 'OutputCodeClassifierScikitsLearnNode', 'OneVsOneClassifierScikitsLearnNode',
+                 'OneVsRestClassifierScikitsLearnNode', 'VotingClassifierScikitsLearnNode']
 
 
 def generate_nodes_list(nodes_dicts):
@@ -400,7 +444,8 @@ def generate_nodes_list(nodes_dicts):
         klass = dct['klass']
         if type(klass) is __builtins__['str']:
             # some of the nodes on the list may be optional
-            if not hasattr(nodes, klass): continue
+            if not hasattr(nodes, klass):
+                continue
             # transform class name into class (needed by automatic tests)
             klass = getattr(nodes, klass)
             dct['klass'] = klass
@@ -423,7 +468,7 @@ def generate_nodes_list(nodes_dicts):
         if (inspect.isclass(node)
             and node_name.endswith('ScikitsLearnNode')
             and (node not in visited)
-            and (node not in excluded)):
+                and (node not in excluded)):
             if issubclass(node, ClassifierNode):
                 nodes_list.append(dict(klass=node,
                                        sup_arg_gen=_rand_labels))
@@ -439,8 +484,9 @@ def generate_nodes_list(nodes_dicts):
         if (inspect.isclass(attr)
             and issubclass(attr, mdp.Node)
             and attr not in visited
-            and attr not in excluded):
+                and attr not in excluded):
             nodes_list.append(attr)
     return nodes_list
+
 
 NODES = generate_nodes_list(NODES)

--- a/mdp/test/test_utils_generic.py
+++ b/mdp/test/test_utils_generic.py
@@ -6,16 +6,17 @@ TESTDECIMALS = {numx.dtype('d'): 12,
                 numx.dtype('F'): 3,
                 }
 
+
 def test_eigenproblem(dtype, range, func):
     """Solve a standard eigenvalue problem."""
     dtype = numx.dtype(dtype)
     dim = 5
     if range:
-        range = (2, dim -1)
+        range = (2, dim - 1)
     else:
         range = None
     a = utils.symrand(dim, dtype)+numx.diag([2.1]*dim).astype(dtype)
-    w,z = func(a, range=range)
+    w, z = func(a, range=range)
     # assertions
     assert_type_equal(z.dtype, dtype)
     w = w.astype(dtype)
@@ -23,17 +24,18 @@ def test_eigenproblem(dtype, range, func):
                                     utils.mult(a, z))).real
     assert_array_almost_equal(diag, w, TESTDECIMALS[dtype])
 
+
 def test_geneigenproblem(dtype, range, func):
     """Solve a generalized eigenvalue problem."""
     dtype = numx.dtype(dtype)
     dim = 5
     if range:
-        range = (2, dim -1)
+        range = (2, dim - 1)
     else:
         range = None
     a = utils.symrand(dim, dtype)
     b = utils.symrand(dim, dtype)+numx.diag([2.1]*dim).astype(dtype)
-    w,z = func(a,b,range=range)
+    w, z = func(a, b, range=range)
     # assertions
     assert z.dtype == dtype
     w = w.astype(dtype)
@@ -45,18 +47,23 @@ def test_geneigenproblem(dtype, range, func):
     assert_array_almost_equal(diag2, numx.ones(diag2.shape[0]),
                               TESTDECIMALS[dtype])
 
+
 test_geneigenproblem.funcs = [utils._symeig._symeig_fake]
 if mdp.utils.symeig is utils._symeig.wrap_eigh:
     test_geneigenproblem.funcs.append(utils._symeig.wrap_eigh)
 
 test_eigenproblem.funcs = test_geneigenproblem.funcs + [utils.nongeneral_svd]
 
+
 def pytest_generate_tests(metafunc):
+    ids = []
+    argvalues = []
     for testtype in ('d', 'f'):
         for therange in (False, True):
             for func in metafunc.function.funcs:
-                funcargs = dict(dtype=testtype,
-                                range=therange,
-                                func=func)
-                theid = "%s, %s, %s" % (func.__name__, testtype, therange)
-                metafunc.addcall(funcargs, id=theid)
+                # build lists
+                argvalues.append((testtype, therange, func))
+                ids.append("%s, %s, %s" % (func.__name__, testtype, therange))
+
+    metafunc.parametrize(argnames='dtype,range,func',
+                         argvalues=argvalues, ids=ids)


### PR DESCRIPTION
This should fix the [issue 39](https://github.com/mdp-toolkit/mdp-toolkit/issues/39).
The changes are based on this [part of the documentation](https://docs.pytest.org/en/3.0.5/parametrize.html). Test ran fine locally and deprecation warnings are gone, as expected.