### PR TITLE
Adding an expansion node for expansion with function sequences that can be recursively computed.

### DIFF
--- a/bimdp/test/conftest.py
+++ b/bimdp/test/conftest.py
@@ -21,7 +21,7 @@ def pytest_configure(config):
         config.option.seed = int(mdp.numx_rand.randint(2**31-1))
 
     # get temp dir
-    py.test.mdp_tempdirname = tempfile.mkdtemp(
+    pytest.mdp_tempdirname = tempfile.mkdtemp(
         suffix='.tmp', prefix='MDPtestdir_')
 
 

--- a/bimdp/test/conftest.py
+++ b/bimdp/test/conftest.py
@@ -13,11 +13,13 @@ To rule this out, please run the tests more than once.
 If you get reproducible failures please report a bug!
 """
 
+
 def pytest_configure(config):
     seed = config.getvalue("seed")
     # if seed was not set by the user, we set one now
     if seed is None or seed == ('NO', 'DEFAULT'):
         config.option.seed = int(mdp.numx_rand.randint(2**31-1))
+
 
 def pytest_unconfigure(config):
     # remove garbage created during tests
@@ -27,8 +29,10 @@ def pytest_unconfigure(config):
     # if pp was monkey-patched, remove any stale pp4mdp directories
     if hasattr(mdp.config, 'pp_monkeypatch_dirname'):
         monkey_dirs = os.path.join(mdp.config.pp_monkeypatch_dirname,
-                                   mdp.parallel.pp_support.TEMPDIR_PREFIX) 
-        [shutil.rmtree(d, ignore_errors=True) for d in glob.glob(monkey_dirs+'*')]
+                                   mdp.parallel.pp_support.TEMPDIR_PREFIX)
+        [shutil.rmtree(d, ignore_errors=True)
+         for d in glob.glob(monkey_dirs+'*')]
+
 
 def pytest_runtest_setup(item):
     # set random seed before running each test
@@ -37,15 +41,18 @@ def pytest_runtest_setup(item):
     # to run the whole test suite again
     mdp.numx_rand.seed(item.config.option.seed)
 
+
 def pytest_addoption(parser):
     """Add random seed option to py.test.
     """
     parser.addoption('--seed', dest='seed', type=int, action='store',
                      help='set random seed')
 
+
 def pytest_report_header(config):
     # report the random seed before and after running the tests
     return '%s\nRandom Seed: %d\n' % (mdp.config.info(), config.option.seed)
+
 
 def pytest_terminal_summary(terminalreporter):
     # add a note about error due to randomness only if an error or a failure
@@ -56,9 +63,3 @@ def pytest_terminal_summary(terminalreporter):
                                           t.config.option.seed))
     if 'failed' in t.stats or 'error' in t.stats:
         t.write_line(_err_str)
-
-def pytest_namespace():
-    # get temporary directory to put temporary files
-    # will be deleted at the end of the test run
-    dirname = tempfile.mkdtemp(suffix='.tmp', prefix='MDPtestdir_')
-    return dict(mdp_tempdirname=dirname)

--- a/bimdp/test/conftest.py
+++ b/bimdp/test/conftest.py
@@ -20,6 +20,10 @@ def pytest_configure(config):
     if seed is None or seed == ('NO', 'DEFAULT'):
         config.option.seed = int(mdp.numx_rand.randint(2**31-1))
 
+    # get temp dir
+    py.test.mdp_tempdirname = tempfile.mkdtemp(
+        suffix='.tmp', prefix='MDPtestdir_')
+
 
 def pytest_unconfigure(config):
     # remove garbage created during tests

--- a/mdp/nodes/__init__.py
+++ b/mdp/nodes/__init__.py
@@ -28,7 +28,7 @@ from .lle_nodes import LLENode, HLLENode
 from .xsfa_nodes import XSFANode, NormalizeNode
 from .gsfa_nodes import GSFANode, iGSFANode
 from .recursive_expansion_nodes import (RecursiveExpansionNode,
-                                        TrainableRecursiveExpansionNode)
+                                        NormalizingRecursiveExpansionNode)
 
 # import internals for use in test_suites
 from .misc_nodes import OneDimensionalHitParade as _OneDimensionalHitParade
@@ -55,7 +55,7 @@ __all__ = ['PCANode', 'WhiteningNode', 'NIPALSNode', 'FastICANode',
            'CutoffNode', 'AdaptiveCutoffNode', 'HistogramNode',
            'IdentityNode', '_OneDimensionalHitParade',
            'OnlineCenteringNode', 'OnlineTimeDiffNode', 'CCIPCANode', 'CCIPCAWhiteningNode', 'MCANode',
-           'IncSFANode', 'RecursiveExpansionNode', 'TrainableRecursiveExpansionNode', ]
+           'IncSFANode', 'RecursiveExpansionNode', 'NormalizingRecursiveExpansionNode', ]
 
 # nodes with external dependencies
 from mdp import config, numx_description, MDPException

--- a/mdp/nodes/__init__.py
+++ b/mdp/nodes/__init__.py
@@ -6,27 +6,28 @@ from .sfa_nodes import SFANode, SFA2Node
 from .ica_nodes import ICANode, CuBICANode, FastICANode, TDSEPNode
 from .neural_gas_nodes import GrowingNeuralGasNode, NeuralGasNode
 from .expansion_nodes import (QuadraticExpansionNode, PolynomialExpansionNode,
-                             RBFExpansionNode, GrowingNeuralGasExpansionNode,
-                             GeneralExpansionNode)
+                              RBFExpansionNode, GrowingNeuralGasExpansionNode,
+                              GeneralExpansionNode)
 from .fda_nodes import FDANode
 from .em_nodes import FANode
 from .misc_nodes import (IdentityNode, HitParadeNode, TimeFramesNode,
-                        TimeDelayNode, TimeDelaySlidingWindowNode,
-                        EtaComputerNode, NoiseNode, NormalNoiseNode,
-                        CutoffNode, HistogramNode, AdaptiveCutoffNode)
+                         TimeDelayNode, TimeDelaySlidingWindowNode,
+                         EtaComputerNode, NoiseNode, NormalNoiseNode,
+                         CutoffNode, HistogramNode, AdaptiveCutoffNode)
 from .isfa_nodes import ISFANode
 from .rbm_nodes import RBMNode, RBMWithLabelsNode
 from .regression_nodes import LinearRegressionNode
 from .classifier_nodes import (SignumClassifier, PerceptronClassifier,
-                              SimpleMarkovClassifier,
-                              DiscreteHopfieldClassifier,
-                              KMeansClassifier, GaussianClassifier,
-                              NearestMeanClassifier, KNNClassifier)
+                               SimpleMarkovClassifier,
+                               DiscreteHopfieldClassifier,
+                               KMeansClassifier, GaussianClassifier,
+                               NearestMeanClassifier, KNNClassifier)
 from .jade import JADENode
 from .nipals import NIPALSNode
 from .lle_nodes import LLENode, HLLENode
 from .xsfa_nodes import XSFANode, NormalizeNode
 from .gsfa_nodes import GSFANode, iGSFANode
+from .recursive_expansion_nodes import RecursiveExpansionNode
 
 # import internals for use in test_suites
 from .misc_nodes import OneDimensionalHitParade as _OneDimensionalHitParade
@@ -42,7 +43,7 @@ __all__ = ['PCANode', 'WhiteningNode', 'NIPALSNode', 'FastICANode',
            'ISFANode', 'XSFANode', 'GSFANode', 'iGSFANode', 'FDANode', 'FANode', 'RBMNode',
            'RBMWithLabelsNode', 'GrowingNeuralGasNode', 'LLENode', 'HLLENode',
            'LinearRegressionNode', 'QuadraticExpansionNode',
-           'PolynomialExpansionNode', 'RBFExpansionNode','GeneralExpansionNode',
+           'PolynomialExpansionNode', 'RBFExpansionNode', 'GeneralExpansionNode',
            'GrowingNeuralGasExpansionNode', 'NeuralGasNode', '_expanded_dim',
            'SignumClassifier',
            'PerceptronClassifier', 'SimpleMarkovClassifier',
@@ -53,7 +54,7 @@ __all__ = ['PCANode', 'WhiteningNode', 'NIPALSNode', 'FastICANode',
            'CutoffNode', 'AdaptiveCutoffNode', 'HistogramNode',
            'IdentityNode', '_OneDimensionalHitParade',
            'OnlineCenteringNode', 'OnlineTimeDiffNode', 'CCIPCANode', 'CCIPCAWhiteningNode', 'MCANode',
-           'IncSFANode',]
+           'IncSFANode', 'RecursiveExpansionNode', ]
 
 # nodes with external dependencies
 from mdp import config, numx_description, MDPException
@@ -111,4 +112,5 @@ utils.fixup_namespace(__name__, __all__ + ['ICANode'],
                        'pca_nodes_online',
                        'mca_nodes_online',
                        'sfa_nodes_online',
+                       'recursive_expansion_nodes',
                        ))

--- a/mdp/nodes/__init__.py
+++ b/mdp/nodes/__init__.py
@@ -27,7 +27,8 @@ from .nipals import NIPALSNode
 from .lle_nodes import LLENode, HLLENode
 from .xsfa_nodes import XSFANode, NormalizeNode
 from .gsfa_nodes import GSFANode, iGSFANode
-from .recursive_expansion_nodes import RecursiveExpansionNode
+from .recursive_expansion_nodes import (RecursiveExpansionNode,
+                                        TrainableRecursiveExpansionNode)
 
 # import internals for use in test_suites
 from .misc_nodes import OneDimensionalHitParade as _OneDimensionalHitParade
@@ -54,7 +55,7 @@ __all__ = ['PCANode', 'WhiteningNode', 'NIPALSNode', 'FastICANode',
            'CutoffNode', 'AdaptiveCutoffNode', 'HistogramNode',
            'IdentityNode', '_OneDimensionalHitParade',
            'OnlineCenteringNode', 'OnlineTimeDiffNode', 'CCIPCANode', 'CCIPCAWhiteningNode', 'MCANode',
-           'IncSFANode', 'RecursiveExpansionNode', ]
+           'IncSFANode', 'RecursiveExpansionNode', 'TrainableRecursiveExpansionNode', ]
 
 # nodes with external dependencies
 from mdp import config, numx_description, MDPException

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -157,7 +157,7 @@ def init_legendre_poly(result, x, pos, cur_var):
     .. note::
 
         The procedure on how an init function is build can be found in the
-        docstring of the init method for
+        docstring of the init function for
         standard polynomials *init_standard_poly*.
 
 
@@ -468,7 +468,10 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
 
         :param recf: Must be in ['standard_poly', 'legendre_poly',
             'legendre_rational', 'chebyshev_poly'] or a tuple similar
-            to those in the recfs dictionary in this module.
+            to those in the recfs dictionary in this module. The procedure
+            on how an init function is build can be found in the docstring
+            of the init and recursion function for standard polynomials 
+            *init_standard_poly* and *recf_standard_poly*, respectively.
         :type recf: tuple or str
 
         :param check: Indicates whether the input data will

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -23,11 +23,18 @@ All orthogonal sequences of functions implemented require input values
 in the right scope, i.e. where the respective polynomials
 are designed to be orthogonal, usually values in [0, 1] or [-1, 1].
 That means, one might have to scale the input appropriately.
-The *TrainableRecursiveExpansionNode* is advisable to use, if the data supplied
+The *NormalizingRecursiveExpansionNode* is advisable to use, if the data supplied
 drops out of this interval or it corresponding cube (i.e. [0,1]^k).
-For convenience, the *TrainableRecursiveExpansionNode* can adapt the
+For convenience, the *NormalizingRecursiveExpansionNode* can adapt the
 value range of the data during a training phase and apply the corresponding
 scaling on execution.
+
+|
+
+.. admonition:: Reference
+
+    Example where orthogonal expansions are advisable to use:
+    URL: https://arxiv.org/abs/1805.08565, section 4.2.1, Figure 11 and A.2.
 """
 import mdp
 from mdp import numx as np
@@ -517,10 +524,10 @@ class RecursiveExpansionNode(_ExpansionNode):
             self.recf = recf[1]
             self.lower = recf[2]
             self.upper = recf[3]
-    
+
     def _get_supported_dtypes(self):
         """Return the list of dtypes supported by this node.
-        
+
         :return: The list of dtypes supported by this node.
         :rtype: list
         """
@@ -618,7 +625,7 @@ class RecursiveExpansionNode(_ExpansionNode):
                 "One or more values lie outside of the function specific domain.")
 
 
-class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
+class NormalizingRecursiveExpansionNode(RecursiveExpansionNode):
     """Recursively computable (orthogonal) expansions and a
     trainable transformation to the domain of the expansions.
 
@@ -635,7 +642,7 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
 
     def __init__(self, degree=1, recf='standard_poly', check=True, with0=True,
                  input_dim=None, dtype=None):
-        """Initialize a TrainableRecursiveExpansionNode.
+        """Initialize a NormalizingRecursiveExpansionNode.
 
         :param degree: The maximum order of the recursive expansion.
             The dimension of the return for single variable inputs will be
@@ -668,12 +675,12 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
             Default is None.
         :type dtype: numpy.dtype or str
         """
-        super(TrainableRecursiveExpansionNode, self).__init__(degree,
-                                                              recf=recf,
-                                                              check=check,
-                                                              with0=with0, 
-                                                              input_dim=input_dim,
-                                                              dtype=dtype)
+        super(NormalizingRecursiveExpansionNode, self).__init__(degree,
+                                                                recf=recf,
+                                                                check=check,
+                                                                with0=with0,
+                                                                input_dim=input_dim,
+                                                                dtype=dtype)
 
         self.amaxcolumn = None
         self.amincolumn = None
@@ -688,7 +695,7 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
         :type x: numpy.ndarray
         """
         self.domain_transformation(x)
-        return super(TrainableRecursiveExpansionNode, self)._execute(x)
+        return super(NormalizingRecursiveExpansionNode, self)._execute(x)
 
     def _train(self, x):
         """Determine coordinatewise and absolute maxima and minima.

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -440,15 +440,22 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
         result[:, 0] = 1.
         pos = 1
 
-        for cur_var in range(num_vars):
-            # preset index for current variable
-            pos, n, special = self.r_init(result, x, pos, cur_var)
-            # single variable recursion
-            while n <= deg:
-                        # recursion step
-                result[:, pos] = self.recf(result, x, special, n, cur_var, pos)
-                n += 1
-                pos += 1
+        if self._degree > 1:
+            for cur_var in range(num_vars):
+                # preset index for current variable
+                pos, n, special = self.r_init(result, x, pos, cur_var)
+                # single variable recursion
+                while n <= deg:
+                            # recursion step
+                    result[:, pos] = self.recf(
+                        result, x, special, n, cur_var, pos)
+                    n += 1
+                    pos += 1
+        # in case input is unreasonable
+        else:
+            result[:, 0] = 1
+            for i in range(num_vars):
+                result[:, i+1] = x[:, i]
 
         todoList = []
         for i in range(1, num_vars):

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -6,9 +6,9 @@ The nodes contained in this module complement the existing
 computed sequences of basis function and by providing implemented
 polynomial and rational recursions that are numerically stable, even
 for high orders. More specifically this module provides the means
-for computing Legendre, Hermite or Chebyshev polynomials if first kind.
+for computing Legendre, Hermite or Chebyshev polynomials of first kind.
 
-Analytically all these polynomial expansions cover the same function space
+Analytically these polynomial expansions cover the same function space
 if they are of same degree. However the conventional
 monome-based polynomial expansion is numerically defective beyond
 degrees of about 20. Input values below one are flattened to
@@ -24,9 +24,9 @@ in the right scope, i.e. where the respective polynomials
 are designed to be orthogonal, usually values in [0, 1] or [-1, 1].
 That means, one might have to scale the input appropriately.
 The *TrainableRecursiveExpansionNode* is advisable to use, if the data supplied
-drops out of this interval or it corresponding cube (i.e. [0,1}^k).
+drops out of this interval or it corresponding cube (i.e. [0,1]^k).
 For convenience, the *TrainableRecursiveExpansionNode* can adapt the
-value range of the data during a training phase and applythe corresponding
+value range of the data during a training phase and apply the corresponding
 scaling on execution.
 """
 import mdp

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -74,7 +74,7 @@ def init_standard_poly(result, x, pos, cur_var):
 
     :returns: The index of the next element that will be computed in the
         recursion, the order of the next element, and the index of a special
-        member.
+        element.
     :rtype: Tuple[int, int, int]
     """
     result[:, pos] = x[:, cur_var]
@@ -179,7 +179,8 @@ def init_legendre_poly(result, x, pos, cur_var):
 
     :returns: The index of the next element that will be computed in the
         recursion, the order of the next element, and the index of a special
-        member.
+        element. Is this case the first order Legendre polynomial of the 
+        current variable is the special element.
     :rtype: Tuple[int, int, int]
     """
     result[:, pos] = x[:, cur_var]
@@ -208,7 +209,8 @@ def recf_legendre_poly(result, x, special, n, cur_var, pos):
     :type x: numpy.ndarray
 
     :param special: Index of a special element to be considered in the
-        recursion formula. E.g. the first order function value.
+        recursion formula. In this case the special element is the 
+        first order Legendre polynomial of the current variable.
     :type special: int
 
     :param n: The order of the function to be computed at this step.
@@ -266,7 +268,8 @@ def init_legendre_rational(result, x, pos, cur_var):
 
     :returns: The index of the next element that will be computed in the
         recursion, the order of the next element, and the index of a special
-        member.
+        member. As we do not need a special element in Legendre rational 
+        functions, the index of the special element is set to None.
     :rtype: Tuple[int, int, int]
     """
     result[:, pos] = (x[:, cur_var]-1.)/(x[:, cur_var]+1.)
@@ -297,7 +300,7 @@ def recf_legendre_rational(result, x, special, n, cur_var, pos):
     :type x: numpy.ndarray
 
     :param special: Index of a special element to be considered in the
-        recursion formula. E.g. the first order function value.
+        recursion formula. In this case it is not needed and will be None.
     :type special: int
 
     :param n: The order of the function to be computed at this step.
@@ -355,7 +358,8 @@ def init_chebyshev_poly(result, x, pos, cur_var):
 
     :returns: The index of the next element that will be computed in the
         recursion, the order of the next element, and the index of a special
-        member.
+        member. The special element is the first Chebyshev polynomial
+        of the current variable.
     :rtype: Tuple[int, int, int]
     """
     result[:, pos] = x[:, cur_var]
@@ -386,7 +390,8 @@ def recf_chebyshev_poly(result, x, special, n, cur_var, pos):
     :type x: numpy.ndarray
 
     :param special: Index of a special element to be considered in the
-        recursion formula. E.g. the first order function value.
+        recursion formula. The special element is the first
+        Chebyshev polynomial of the current variable.
     :type special: int
 
     :param n: The order of the function to be computed at this step.

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -622,6 +622,39 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
 
     def __init__(self, degree=1, recf='standard_poly', check=True, with0=True,
                  input_dim=None, dtype=None):
+        """Initialize a TrainableRecursiveExpansionNode.
+
+        :param degree: The maximum order of the recursive expansion.
+            The dimension of the return for single variable inputs will be
+            equal to this value if with0 == False.
+        :type degree: int
+
+        :param recf: Must be in ['standard_poly', 'legendre_poly',
+            'legendre_rational', 'chebyshev_poly'] or a tuple similar
+            to those in the recfs dictionary in this module. The procedure
+            on how an init function is build can be found in the docstring
+            of the init and recursion function for standard polynomials 
+            *init_standard_poly* and *recf_standard_poly*, respectively.
+        :type recf: tuple or str
+
+        :param check: Indicates whether the input data will
+            be checked for compliance to the domain on which the function
+            sequence selected is defined or orthogonal. The check will be made
+            automatically in the execute method.
+        :type check: bool
+
+        :param with0: Parameter that specificies whether the zero-th order
+            element is to be included at the beginning of the result array.
+        :type with0: bool
+
+        :param input_dim: Dimensionality of the input.
+            Default is None.
+        :type input_dim: int
+
+        :param dtype: Datatype of the input.
+            Default is None.
+        :type dtype: numpy.dtype or str
+        """
         super(TrainableRecursiveExpansionNode, self).__init__(degree,
                                                               recf=recf, check=check,
                                                               with0=with0, input_dim=input_dim,

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -46,7 +46,7 @@ def init_standard_poly(result, x, pos, cur_var):
         In the case of standard polynomials this is *pos+1*.
         The second index indicates the order of the element on which
         the recursion is applied first. In the case of standard polynomials
-        this is order is equal to 2. The third index specifies the index
+        this order is equal to 2. The third index specifies the index
         of a special member for use in the recursion. This might be a
         constant order element that is used in every recursion. In the case
         of standard polynomials this can be *pos* (as this is where *x* is) or
@@ -57,7 +57,7 @@ def init_standard_poly(result, x, pos, cur_var):
     P_1 = x.
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -102,7 +102,7 @@ def recf_standard_poly(result, x, special, n, cur_var, pos):
 
             >>> result[:, pos-1]
 
-        Using the the index of the special variable we specified in our init
+        Using the index of the special variable we specified in our init
         function we can set the return value to::
 
             >>> result[:, pos-1]*result[:, special]
@@ -113,12 +113,12 @@ def recf_standard_poly(result, x, special, n, cur_var, pos):
             >> result[:, pos-1]*x[:, cur_var]
 
         The recursion is natively applied to all variables contained in the data
-        one after another and the results saved in the
+        one after another and the results are stored in the
         one-dimensional result array.
 
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -156,13 +156,13 @@ def init_legendre_poly(result, x, pos, cur_var):
 
     .. note::
 
-        The procedure on how an init function is build can be found in the
+        The procedure on how an init function is built can be found in the
         docstring of the init function for
         standard polynomials *init_standard_poly*.
 
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -195,12 +195,12 @@ def recf_legendre_poly(result, x, special, n, cur_var, pos):
 
         .. note::
 
-        The procedure on how an recursion function is build can be found in the
+        The procedure on how an recursion function is built can be found in the
         docstring of the recursion function for
         standard polynomials *recf_standard_poly*.
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -243,13 +243,13 @@ def init_legendre_rational(result, x, pos, cur_var):
 
     .. note::
 
-        The procedure on how an init function is build can be found in the
+        The procedure on how an init function is built can be found in the
         docstring of the init function for
         standard polynomials *init_standard_poly*.
 
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -283,13 +283,13 @@ def recf_legendre_rational(result, x, special, n, cur_var, pos):
 
     .. note::
 
-        The procedure on how an recursion function is build can be found in the
+        The procedure on how an recursion function is built can be found in the
         docstring of the recursion function for
         standard polynomials *recf_standard_poly*.
 
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -332,13 +332,13 @@ def init_chebyshev_poly(result, x, pos, cur_var):
 
     .. note::
 
-        The procedure on how an init function is build can be found in the
+        The procedure on how an init function is built can be found in the
         docstring of the init function for
         standard polynomials *init_standard_poly*.
 
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -372,13 +372,13 @@ def recf_chebyshev_poly(result, x, special, n, cur_var, pos):
 
     .. note::
 
-        The procedure on how an recursion function is build can be found in the
+        The procedure on how an recursion function is built can be found in the
         docstring of the recursion function for
         standard polynomials *recf_standard_poly*.
 
 
     :param result: Contains the observations along the first dimension
-        and the different function values of expansion w.r.t. an observation
+        and the function values of expansion w.r.t. an observation
         along the second dimension.
     :type result: numpy.ndarray
 
@@ -448,13 +448,13 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
 
     .. attribute:: lower
 
-        The lower bound of the domain, on which the recursion
-        function sequence selected, is defined or orthogonal.
+        The lower bound of the domain on which the recursion function is
+        defined or orthogonal.
 
     .. attribute:: upper
 
-        The upper bound of the domain, on which the recursion
-        function sequence selected, is defined or orthogonal.
+        The lower bound of the domain on which the recursion function is
+        defined or orthogonal.
     """
 
     def __init__(self, degree=1, recf='standard_poly', check=False,
@@ -469,7 +469,7 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
         :param recf: Must be in ['standard_poly', 'legendre_poly',
             'legendre_rational', 'chebyshev_poly'] or a tuple similar
             to those in the recfs dictionary in this module. The procedure
-            on how an init function is build can be found in the docstring
+            on how an init function is built can be found in the docstring
             of the init and recursion function for standard polynomials 
             *init_standard_poly* and *recf_standard_poly*, respectively.
         :type recf: tuple or str
@@ -517,7 +517,7 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
         """Return the size of a vector of dimension 'dim' after
         an expansion of degree 'self._degree'.
 
-        :param num_vars: The number of different variables in the
+        :param num_vars: The number of variables in the
             supplied data. This value is equal to x.shape[1].
         :type num_vars: int
 
@@ -532,7 +532,7 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
         """Expansion of the data.
 
         :param x: The data to be expanded. Observations/samples must
-            be along the first axis, different variables along the second.
+            be along the first axis, variables along the second.
         :type x: numpy.ndarray
 
         :returns: The expansion of x with observations/samples along the
@@ -588,7 +588,7 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
             the function sequence selected is defined or orthogonal.
 
         :param x: The data to be expanded. Observations/samples must
-            be along the first axis, different variables along the second.
+            be along the first axis, variables along the second.
         :type x: numpy.ndarray
 
         :param prec: (Numerical) tolerance when checking validity.
@@ -611,13 +611,13 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
 
     .. attribute:: lower
 
-        The lower bound of the domain, on which the recursion
-        function sequence selected, is defined or orthogonal.
+        The lower bound of the domain on which the recursion
+        function is defined or orthogonal.
 
     .. attribute:: upper
 
-        The upper bound of the domain, on which the recursion
-        function sequence selected, is defined or orthogonal.
+        The lower bound of the domain on which the recursion function
+        is defined or orthogonal.
     """
 
     def __init__(self, degree=1, recf='standard_poly', check=True, with0=True,
@@ -632,7 +632,7 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
         :param recf: Must be in ['standard_poly', 'legendre_poly',
             'legendre_rational', 'chebyshev_poly'] or a tuple similar
             to those in the recfs dictionary in this module. The procedure
-            on how an init function is build can be found in the docstring
+            on how an init function is built can be found in the docstring
             of the init and recursion function for standard polynomials 
             *init_standard_poly* and *recf_standard_poly*, respectively.
         :type recf: tuple or str
@@ -669,7 +669,7 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
         """Apply the transformation and execute RecursiveExpansionNode.
 
         :param x: The data to be expanded. Observations/samples must
-            be along the first axis, different variables along the second.
+            be along the first axis, variables along the second.
         :type x: numpy.ndarray
         """
         self.domain_transformation(x)
@@ -679,7 +679,7 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
         """Determine coordinatewise and absolute maxima and minima.
 
         :param x: Chuck of data to be used for training. Observations/samples
-            must be along the first axis, different variables along the second.
+            must be along the first axis, variables along the second.
         :type x: numpy.ndarray
 
         The values are used to generate a transformation to the valid domain

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -1,0 +1,489 @@
+"""
+This module provides nodes for recursive computation of sequences of functions.
+"""
+import mdp
+from mdp import numx as np
+from mdp.nodes import PolynomialExpansionNode
+__docformat__ = "restructuredtext en"
+
+
+def recf_standard_poly(result, x, special, n, cur_var, pos):
+    """Implementation of the recursion formula for standard polynomials.
+    The recursion formula is P_n = P_{n-1} * x.
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param special: Index of a special element to be considered in the
+        recursion formula. E.g. the first order function value.
+    :type special: int
+
+    :param n: The order of the function to be computed at this step.
+    :type n: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type int: int
+
+    :returns: The vectorized result (along the observations) of the
+        n-th recursion step of the cur_var-th variable.
+    :rtype: numpy.ndarray
+    """
+    return result[:, pos-1]*result[:, special]
+
+
+def init_standard_poly(result, x, pos, cur_var):
+    """Initialize the first order before starting the recursion.
+
+    Mathematically this amounts to
+    P_1 = x.
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type int: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :returns: The index of the next element that will be computed in the
+        recursion, the order of the next element, and the index of a special
+        member.
+    :rtype: numpy.ndarray
+    """
+    result[:, pos] = x[:, cur_var]
+    # pos, n, special
+    return pos+1, 2, pos
+
+
+def init_legendre_poly(result, x, pos, cur_var):
+    """Initialize  the first and second order before starting the recursion.
+
+    Mathematically this amounts to
+    P_1 = x
+    P_2 = 3/2 * P_1*P_1 - 1/2 .
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type int: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :returns: The index of the next element that will be computed in the
+        recursion, the order of the next element, and the index of a special
+        member.
+    :rtype: numpy.ndarray
+    """
+    result[:, pos] = x[:, cur_var]
+    # after the first variable this is needed (no zero order available)
+    result[:, pos+1] = 3./2.*result[:, pos] * result[:, pos] - \
+        1./2.
+    return pos+2, 3, pos
+
+
+def recf_legendre_poly(result, x, special, n, cur_var, pos):
+    """Implementation of the recursion formula for Legendre polynomials.
+    The recursion formula is Bonnet's recursion formula
+    P_n = (2n-1)/n * x * P_ {n-1}  - (n-1)* P_{n-2}.
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param special: Index of a special element to be considered in the
+        recursion formula. E.g. the first order function value.
+    :type special: int
+
+    :param n: The order of the function to be computed at this step.
+    :type n: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type int: int
+
+    :returns: The vectorized result (along the observations) of the
+        n-th recursion step of the cur_var-th variable.
+    :rtype: numpy.ndarray
+
+    .. admonition:: Reference
+
+        https://en.wikipedia.org/wiki/Legendre_polynomials
+    """
+    return (2.*n-1.)/n*result[:, special] * result[:, pos-1] -\
+        (n-1.)/n*result[:, pos-2]
+
+
+def init_legendre_rational(result, x, pos, cur_var):
+    """Initialize the first and second order before starting the recursion.
+
+    Mathematically this amounts to
+    R_1 = (x-1)/(x+1)
+    R_2 = 3/2 * (x-1)/(x+1)*P_1 - 1/2.
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type int: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :returns: The index of the next element that will be computed in the
+        recursion, the order of the next element, and the index of a special
+        member.
+    :rtype: numpy.ndarray
+    """
+    result[:, pos] = (x[:, cur_var]-1.)/(x[:, cur_var]+1.)
+    # after the first variable the second order is needed (no zero order available)
+    result[:, pos+1] = 3./2.*(x[:, cur_var]-1.) / (x[:, cur_var]+1.) \
+        * result[:, pos] - 1. / 2.
+    return pos+2, 3, None
+
+
+def recf_legendre_rational(result, x, special, n, cur_var, pos):
+    """Implementation of the recursion formula for Legendre rational functions.
+    The recursion formula is
+    R_n = (2n-1)/n * (x-1)/(x+1) R_{n-1} - (n-1)/n R_{n-2}.
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param special: Index of a special element to be considered in the
+        recursion formula. E.g. the first order function value.
+    :type special: int
+
+    :param n: The order of the function to be computed at this step.
+    :type n: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type int: int
+
+    :returns: The vectorized result (along the observations) of the
+        n-th recursion step of the cur_var-th variable.
+    :rtype: numpy.ndarray
+
+    .. admonition:: Reference
+
+        https://en.wikipedia.org/wiki/Legendre_rational_functions
+    """
+    return (2.*n-1.)/n*(x[:, cur_var]-1.) / (x[:, cur_var]+1.) \
+        * result[:, pos-1] - (n-1.) / n * result[:, pos-2]
+
+
+def init_chebyshev_poly(result, x, pos, cur_var):
+    """Initialize the first and second order before starting the recursion.
+
+    Mathematically this amounts to
+    T_1 = x
+    T_2 = 2xT_1 -1.
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type int: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :returns: The index of the next element that will be computed in the
+        recursion, the order of the next element, and the index of a special
+        member.
+    :rtype: numpy.ndarray
+    """
+    result[:, pos] = x[:, cur_var]
+    # after the first variable this is needed (no zero order available)
+    result[:, pos+1] = 2.*x[:, cur_var] * result[:, pos] - 1
+    return pos+2, 3, pos
+
+
+def recf_chebyshev_poly(result, x, special, n, cur_var, pos):
+    """Implementation of the recursion formula for Chebyshev polynomials
+    of the first kind.
+    The recursion formula is
+    T_n = 2xT_{n-1} - T_{n-2}.
+
+    :param result: Contains the observations along the first dimension
+        and the different function values of expansion w.r.t. an observation
+        along the second dimension.
+    :type result: numpy.ndarray
+
+    :param x: The data to be expanded.
+    :type x: numpy.ndarray
+
+    :param special: Index of a special element to be considered in the
+        recursion formula. E.g. the first order function value.
+    :type special: int
+
+    :param n: The order of the function to be computed at this step.
+    :type n: int
+
+    :param cur_var: The index of the current variable to be considered in the
+        recursion. This value will have to be lower than x.shape[1].
+    :type cur_var: int
+
+    :param pos: The index of the element to be computed, along the second
+        dimension of result.
+    :type pos: int
+
+    :returns: The vectorized result (along the observations) of the
+        n-th recursion step of the cur_var-th variable.
+    :rtype: numpy.ndarray
+
+    .. admonition:: Reference
+
+        https://en.wikipedia.org/wiki/Chebyshev_polynomials
+    """
+    return 2. * x[:, cur_var] * result[:, pos-1] - result[:, pos-2]
+
+
+# collect the recusions and set the corresponding intervals
+recfs = {'standard_poly': (init_standard_poly, recf_standard_poly,
+                           -float('Inf'), float('Inf')),
+         'legendre_poly': (init_legendre_poly, recf_legendre_poly,
+                           -1, 1),
+         'legendre_rational': (init_legendre_rational,
+                               recf_legendre_rational, 0, float('Inf')),
+         'chebyshev_poly': (init_chebyshev_poly,
+                            recf_chebyshev_poly, -1, 1)}
+
+
+def process(off, leadVar, leadDeg, deg, pos, result, todoList):
+    """Computes an inplace not exactly tensorproduct of the given
+    basis functions (only the simplex of the single variable bases,
+    as we limit the multi variable polynomials by a given maximum degree).
+    """
+    for v in range(leadVar):
+        l = deg-leadDeg
+        k = 1+deg*v
+        for d in range(1, deg-leadDeg+1):
+            l = deg+1-leadDeg-d
+            result[:, pos:pos+l] = result[:, 1+off:1+off+l] * result[:, k:k+1]
+            if l > 1 and leadVar > 0:
+                todoList.append((pos-1, v, leadDeg+d))
+
+            pos += l
+            k += 1
+            l -= 1
+
+    return pos
+
+
+class RecursiveExpansionNode(PolynomialExpansionNode):
+    """Recursively computable (orthogonal) expansions.
+
+    .. attribute:: lower
+
+        The lower bound of the interval, on which the recursion
+        function sequence selected, is defined or orthogonal.
+
+    .. attribute:: upper
+
+        The upper bound of the interval, on which the recursion
+        function sequence selected, is defined or orthogonal.
+    """
+
+    def __init__(self, degree=2, recf='standard_poly', check=False,
+                 with0=True, input_dim=None, dtype=None):
+        """Initialize a RecursiveExpansionNode.
+
+        :param degree: The maximum order of the recursive expansion.
+            The dimension of the return for single variable inputs will be
+            equal to this value if with0 == False.
+        :type degree: int
+
+        :param recf: Must be in ['standard_poly', 'legendre_poly',
+            'legendre_rational', 'chebyshev_poly'] or a tuply similar
+            to those in the recfs dictionary in this module.
+        :type recf: tuple
+
+        :param check: Indicates whether the input data will
+            be checked for compliance to the interval on which the function
+            sequence selected is defined or orthogonal. The check will be made
+            automatically in the execute method.
+        :type check: bool
+
+        :param with0: Parameter that specificies whether the zero-th order
+            element is to be included at the beginning of the result array.
+        :type with0: bool
+
+        :param input_dim: Dimensionality of the input.
+            Default is None.
+        :type input_dim: int
+
+        :param dtype: Datatype of the input.
+            Default is None.
+        :type dtype: numpy.dtype, str
+        """
+        super(RecursiveExpansionNode, self).__init__(
+            degree, input_dim, dtype)
+
+        self.check = check
+        self.with0 = with0
+        # if in dictionary
+        if recf in recfs:
+                # intialises the elements not based on recursion formula
+            self.r_init = recfs[recf][0]
+            # the recursion function
+            self.recf = recfs[recf][1]
+            # interval on which data must be
+            self.upper = recfs[recf][2]
+            self.lower = recfs[recf][3]
+        # if supplied by user
+        else:
+            self.r_init = recf[0]
+            self.recf = recf[1]
+            self.upper = recf[2]
+            self.lower = recf[3]
+
+    def expanded_dim(self, num_vars):
+        """Return the size of a vector of dimension 'dim' after
+        an expansion of degree 'self._degree'.
+
+        :param num_vars: The number of different variables in the
+            supplied data. This value is equal to x.shape[1].
+        :type num_vars: int
+
+        :retruns: The size of the result of execute along the second axis,
+            that is, the dimension of the expansion.
+        :rtype: int
+        """
+        res = super(RecursiveExpansionNode, self).expanded_dim(num_vars)
+        return res+1 if self.with0 else res
+
+    def _execute(self, x):
+        """Expansion of the data.
+
+        :param x: The data to be expanded. Observations/samples must
+            be along the first axis, different variables along the second.
+        :type x: numpy.ndarray
+
+        :returns: The expansion of x with observations/samples along the
+            first axis and corresponding function values (expansion)
+            along the second axis.
+        :rtype: numpy.ndarray
+        """
+
+        num_vars = x.shape[1]
+        num_samples = x.shape[0]
+
+        _with0 = hasattr(self, "with0") and self.with0
+        deg = self._degree
+        dim = self.expanded_dim(num_vars)
+        dim += 1 if not self.with0 else 0
+        result = np.empty(
+            [num_samples, dim], dtype=self.dtype)
+
+        if self.check:
+            self.check_interval(x)
+
+        result[:, 0] = 1.
+        pos = 1
+
+        if self._degree > 1:
+            for cur_var in range(num_vars):
+                # preset index for current variable
+                pos, n, special = self.r_init(result, x, pos, cur_var)
+                # single variable recursion
+                while n <= deg:
+                            # recursion step
+                    result[:, pos] = self.recf(
+                        result, x, special, n, cur_var, pos)
+                    n += 1
+                    pos += 1
+        # in case input is unreasonable
+        else:
+            result[:, 0] = 1
+            for i in range(num_vars):
+                result[:, i+1] = x[:, i]
+
+        todoList = []
+        for i in range(1, num_vars):
+            todoList.append((i*deg, i, 1))
+        # compute the rest of the "simplex" product
+        while len(todoList) > 0:
+            # pos = process(*todoList.pop(0), deg, pos, result, todoList)
+            pos = process(*todoList.pop(0)+(deg, pos, result, todoList))
+        return (result if _with0 else result[:, 1:])
+
+    def check_interval(self, x, prec=1e-6):
+        """Checks for compliance of the data x with the interval on which
+            the function sequence selected is defined or orthogonal.
+
+        :raise ValueError: If one or more values lie outside of the function
+            specific interval.
+        """
+        xmax = np.amax(x)-prec
+        xmin = np.amin(x)+prec
+
+        if (self.upper < xmax) or (self.lower > xmin):
+            raise ValueError(
+                "One or more values lie outside of the function specific interval.")
+
+    @staticmethod
+    def is_trainable():
+        return False
+
+    @staticmethod
+    def is_invertible():
+        return False

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -2,8 +2,8 @@
 This module provides nodes for recursive computation of sequences of functions.
 
 The nodes contained in this module complement the existing
-PolynomialExpansionNode by generalization to arbitrary recursively
-computer sequences of basis function and by providing implemented
+*PolynomialExpansionNode* by generalization to arbitrary recursively
+computed sequences of basis function and by providing implemented
 polynomial and rational recursions that are numerically stable, even
 for high orders. More specifically this module provides the means
 for computing Legendre, Hermite or Chebyshev polynomials if first kind.

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -343,7 +343,7 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
         function sequence selected, is defined or orthogonal.
     """
 
-    def __init__(self, degree, recf='standard_poly', check=False,
+    def __init__(self, degree=1, recf='standard_poly', check=False,
                  with0=True, input_dim=None, dtype=None):
         """Initialize a RecursiveExpansionNode.
 
@@ -387,14 +387,14 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
             # the recursion function
             self.recf = recfs[recf][1]
             # interval on which data must be
-            self.upper = recfs[recf][2]
-            self.lower = recfs[recf][3]
+            self.lower = recfs[recf][2]
+            self.upper = recfs[recf][3]
         # if supplied by user
         else:
             self.r_init = recf[0]
             self.recf = recf[1]
-            self.upper = recf[2]
-            self.lower = recf[3]
+            self.lower = recf[2]
+            self.upper = recf[3]
 
     def expanded_dim(self, num_vars):
         """Return the size of a vector of dimension 'dim' after
@@ -511,9 +511,9 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
         function sequence selected, is defined or orthogonal.
     """
 
-    def __init__(self, degree, recf='standard_poly', check=True, with0=True,
+    def __init__(self, degree=1, recf='standard_poly', check=True, with0=True,
                  input_dim=None, dtype=None):
-        super(TrainableRecursiveExpansionNode, self).__init__(self, degree,
+        super(TrainableRecursiveExpansionNode, self).__init__(degree,
                                                               recf=recf, check=check,
                                                               with0=with0, input_dim=input_dim,
                                                               dtype=dtype)
@@ -531,7 +531,7 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
         :type x: numpy.ndarray
         """
         self.domain_transformation(x)
-        return super(TrainableRecursiveExpansionNode, self)._execute(self, x)
+        return super(TrainableRecursiveExpansionNode, self)._execute(x)
 
     def _train(self, x):
         """Determine coordinatewise and absolute maxima and minima.
@@ -569,12 +569,15 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
         which the node is executed on, does not contain more "malign outliers"
         than the ones already supplied during training.
         """
+
         # the following conditionals go through different domain types
         if self.lower is None or self.upper is None:
-            def f(x): return x
+            def f(x):
+                return x
 
         elif self.lower == -float('Inf') and self.upper == float('Inf'):
-            def f(x): return x
+            def f(x):
+                return x
 
         elif self.lower == -float('Inf'):
             self.diff = self.amaxcolumn-self.upper

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -453,7 +453,7 @@ class RecursiveExpansionNode(PolynomialExpansionNode):
 
     .. attribute:: upper
 
-        The lower bound of the domain on which the recursion function is
+        The upper bound of the domain on which the recursion function is
         defined or orthogonal.
     """
 
@@ -616,7 +616,7 @@ class TrainableRecursiveExpansionNode(RecursiveExpansionNode):
 
     .. attribute:: upper
 
-        The lower bound of the domain on which the recursion function
+        The upper bound of the domain on which the recursion function
         is defined or orthogonal.
     """
 

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -43,14 +43,14 @@ def init_standard_poly(result, x, pos, cur_var):
         An init function also returns some indices relevant to further
         steps in which the recursion formula is applied. The
         first index indicates where the recursion is applied first.
-        In the case of standard polynomials this is pos+1.
+        In the case of standard polynomials this is *pos+1*.
         The second index indicates the order of the element on which
-        the recursion si applied first. In the case of standard polynomials
+        the recursion is applied first. In the case of standard polynomials
         this is order is equal to 2. The third index specifies the index
         of a special member for use in the recursion. This might be a
         constant order element that is used in every recursion. In the case
-        of standard polynomials this can be pos (as this is where x is) or
-        None (as x is passed to the recursion anyway).
+        of standard polynomials this can be *pos* (as this is where *x* is) or
+        None (as *x* is passed to the recursion anyway).
 
 
     Mathematically this amounts to
@@ -91,7 +91,7 @@ def recf_standard_poly(result, x, special, n, cur_var, pos):
 
         We translate this recursion formula into code as follows.
 
-        We leave out the leeft part of the equation, as the
+        We leave out the left part of the equation, as the
         return value is automatically set to the n-th order
         expansion of the current variable, namely::
 

--- a/mdp/test/conftest.py
+++ b/mdp/test/conftest.py
@@ -21,7 +21,7 @@ def pytest_configure(config):
         config.option.seed = int(mdp.numx_rand.randint(2**31-1))
 
     # get temp dir
-    py.test.mdp_tempdirname = tempfile.mkdtemp(
+    pytest.mdp_tempdirname = tempfile.mkdtemp(
         suffix='.tmp', prefix='MDPtestdir_')
 
 

--- a/mdp/test/conftest.py
+++ b/mdp/test/conftest.py
@@ -13,11 +13,13 @@ To rule this out, please run the tests more than once.
 If you get reproducible failures please report a bug!
 """
 
+
 def pytest_configure(config):
     seed = config.getvalue("seed")
     # if seed was not set by the user, we set one now
     if seed is None or seed == ('NO', 'DEFAULT'):
         config.option.seed = int(mdp.numx_rand.randint(2**31-1))
+
 
 def pytest_unconfigure(config):
     # remove garbage created during tests
@@ -27,8 +29,10 @@ def pytest_unconfigure(config):
     # if pp was monkey-patched, remove any stale pp4mdp directories
     if hasattr(mdp.config, 'pp_monkeypatch_dirname'):
         monkey_dirs = os.path.join(mdp.config.pp_monkeypatch_dirname,
-                                   mdp.parallel.pp_support.TEMPDIR_PREFIX) 
-        [shutil.rmtree(d, ignore_errors=True) for d in glob.glob(monkey_dirs+'*')]
+                                   mdp.parallel.pp_support.TEMPDIR_PREFIX)
+        [shutil.rmtree(d, ignore_errors=True)
+         for d in glob.glob(monkey_dirs+'*')]
+
 
 def pytest_runtest_setup(item):
     # set random seed before running each test
@@ -37,15 +41,18 @@ def pytest_runtest_setup(item):
     # to run the whole test suite again
     mdp.numx_rand.seed(item.config.option.seed)
 
+
 def pytest_addoption(parser):
     """Add random seed option to py.test.
     """
     parser.addoption('--seed', dest='seed', type=int, action='store',
                      help='set random seed')
 
+
 def pytest_report_header(config):
     # report the random seed before and after running the tests
     return '%s\nRandom Seed: %d\n' % (mdp.config.info(), config.option.seed)
+
 
 def pytest_terminal_summary(terminalreporter):
     # add a note about error due to randomness only if an error or a failure
@@ -56,9 +63,3 @@ def pytest_terminal_summary(terminalreporter):
                                           t.config.option.seed))
     if 'failed' in t.stats or 'error' in t.stats:
         t.write_line(_err_str)
-
-def pytest_namespace():
-    # get temporary directory to put temporary files
-    # will be deleted at the end of the test run
-    dirname = tempfile.mkdtemp(suffix='.tmp', prefix='MDPtestdir_')
-    return dict(mdp_tempdirname=dirname)

--- a/mdp/test/conftest.py
+++ b/mdp/test/conftest.py
@@ -20,6 +20,10 @@ def pytest_configure(config):
     if seed is None or seed == ('NO', 'DEFAULT'):
         config.option.seed = int(mdp.numx_rand.randint(2**31-1))
 
+    # get temp dir
+    py.test.mdp_tempdirname = tempfile.mkdtemp(
+        suffix='.tmp', prefix='MDPtestdir_')
+
 
 def pytest_unconfigure(config):
     # remove garbage created during tests

--- a/mdp/test/test_NormalizingRecursiveExpansionNode.py
+++ b/mdp/test/test_NormalizingRecursiveExpansionNode.py
@@ -1,16 +1,16 @@
 """
-Tests for the TrainableRecursiveExpansionNode.
+Tests for the NormalizingRecursiveExpansionNode.
 """
 
 from mdp.nodes import (RecursiveExpansionNode,
-                       TrainableRecursiveExpansionNode)
+                       NormalizingRecursiveExpansionNode)
 from mdp.nodes.recursive_expansion_nodes import recfs
 from mdp.test._tools import *
 from mdp import numx as np
 import py.test
 
 
-def test_TrainableRecursiveExpansionNode():
+def test_NormalizingRecursiveExpansionNode():
     """Essentially testing the domain transformation."""
     degree = 10
     episodes = 5
@@ -19,8 +19,8 @@ def test_TrainableRecursiveExpansionNode():
 
     for func_name in recfs:
         x = np.zeros((0, num_vars))
-        expn = TrainableRecursiveExpansionNode(degree, recf=func_name,
-                                               check=True, with0=True)
+        expn = NormalizingRecursiveExpansionNode(degree, recf=func_name,
+                                                 check=True, with0=True)
         for i in range(episodes):
             chunk = (np.random.rand(num_obs, num_vars)-0.5)*1000
             expn.train(chunk)

--- a/mdp/test/test_RecursiveExpansionNode.py
+++ b/mdp/test/test_RecursiveExpansionNode.py
@@ -1,0 +1,181 @@
+"""
+Tests for the RecursiveExpansionNode.
+"""
+
+from mdp.nodes import PolynomialExpansionNode
+from mdp.nodes import RecursiveExpansionNode
+from mdp.test._tools import *
+from mdp import numx as np
+import py.test
+
+
+def test_RecursiveExpansionNode1():
+    """Testing the one-dimensional expansion."""
+    for functup in funcs:
+        func = functup[0]
+        degree = functup[1]
+        name = functup[2]
+        data = np.random.rand(1, 1)
+
+        expn = RecursiveExpansionNode(
+            degree, recf=name, check=False, with0=True)
+        nodeexp = expn.execute(data)
+        assert_array_almost_equal(nodeexp,
+                                  func(data[:, 0], degree), decimal-3)
+        print('Single dim '+name + ' equal')
+
+
+def test_RecursiveExpansionNode2():
+    """Testing the tensor-base."""
+    data = 1e-6+np.random.rand(10, 4)
+    for functup in funcs:
+        func = functup[0]
+        degree = 4
+        name = functup[2]
+        recexpn = RecursiveExpansionNode(degree, recf=name,
+                                         check=False, with0=True)
+        resrec = recexpn.execute(data)
+        restensor = np.array([get_handcomputed_function_tensor(data[i, :], func, degree)
+                              for i in range(data.shape[0])])
+
+        ressimplex = np.array(
+            [makeSimplex(restensor[i, :, :, :, :]) for i in range(data.shape[0])])
+        assert_array_almost_equal(resrec, ressimplex, decimal-3)
+        print('Multi dim ' + name + ' equal')
+
+
+def get_chebyshev_poly(x, degree):
+    p = np.ndarray((x.shape[0], 7))
+    p[:, 0] = 1.
+    p[:, 1] = x
+    p[:, 2] = 2.*x*x-1.
+    p[:, 3] = 4.*x**3-3.*x
+    p[:, 4] = 8.*x**4-8.*x**2+1.
+    p[:, 5] = 16.*x**5-20.*x**3+5.*x
+    p[:, 6] = 32.*x**6-48.*x**4+18.*x*x-1.
+    return p[:, :degree+1]
+
+
+def get_legendre_ratio(x, degree):
+    p = np.ndarray((x.shape[0], 5))
+    p[:, 0] = 1.
+    p[:, 1] = (x-1.)/(x+1.)
+    p[:, 2] = (x*x-4.*x+1.)/(x+1.)**2
+    p[:, 3] = (x**3-9.*x*x+9.*x-1.)/(x+1.)**3
+    p[:, 4] = (x**4-16.*x**3+36.*x*x-16.*x+1.)/(x+1.)**4
+    return p[:, :degree+1]
+
+
+def get_legendre_poly(x, degree):
+    p = np.ndarray((x.shape[0], 7))
+    p[:, 0] = 1.
+    p[:, 1] = x
+    p[:, 2] = 0.5*(3.*x*x-1.)
+    p[:, 3] = 0.5*(5.*x*x-3.)*x
+    p[:, 4] = 1./8.*(35.*x**4-30.*x*x+3.)
+    p[:, 5] = 1./8.*(63.*x**5-70.*x**3+15.*x)
+    p[:, 6] = 1./16.*(231.*x**6-315.*x**4+105.*x*x-5.)
+    return p[:, :degree+1]
+
+
+def get_standard_poly(x, degree):
+    p = np.ndarray((x.shape[0], 7))
+    p[:, 0] = 1.
+    p[:, 1] = x
+    p[:, 2] = x*x
+    p[:, 3] = x**3
+    p[:, 4] = x**4
+    p[:, 5] = x**5
+    p[:, 6] = x**6
+    return p[:, :degree+1]
+
+
+def get_handcomputed_function_tensor(x, func, degree):
+    """x must be of shape (4,)."""
+    outtensor = np.zeros((degree+1,)*4)
+
+    outtensor[:, 0, 0, 0] = func(x[np.newaxis, 0], degree)
+    outtensor[0, :, 0, 0] = func(x[np.newaxis, 1], degree)
+    outtensor[0, 0, :, 0] = func(x[np.newaxis, 2], degree)
+    outtensor[0, 0, 0, :] = func(x[np.newaxis, 3], degree)
+    for i in range(degree+1):
+        outtensor[:, i, 0, 0] = outtensor[:, 0, 0, 0]*outtensor[0, i, 0, 0]
+
+    for i in range(degree+1):
+        outtensor[:, :, i, 0] = outtensor[:, :, 0, 0] * outtensor[0, 0, i, 0]
+
+    for i in range(degree+1):
+        outtensor[:, :, :, i] = outtensor[:, :, :, 0] * outtensor[0, 0, 0, i]
+
+    return outtensor
+
+
+funcs = [(get_legendre_poly, 6, 'legendre_poly'),
+         (get_legendre_ratio, 4, 'legendre_rational'),
+         (get_standard_poly, 6, 'standard_poly'),
+         (get_chebyshev_poly, 6, 'chebyshev_poly')]
+
+
+def makeSimplex(tensor):
+    simplex = np.concatenate(
+        (tensor[:, 0, 0, 0], tensor[0, 1:, 0, 0], tensor[0, 0, 1:, 0],
+         tensor[0, 0, 0, 1:]))
+    x1 = tensor[1, 0, 0, 0]
+    x2 = tensor[2, 0, 0, 0]
+    x3 = tensor[3, 0, 0, 0]
+
+    y1 = tensor[0, 1, 0, 0]
+    y2 = tensor[0, 2, 0, 0]
+    y3 = tensor[0, 3, 0, 0]
+
+    z1 = tensor[0, 0, 1, 0]
+    z2 = tensor[0, 0, 2, 0]
+    z3 = tensor[0, 0, 3, 0]
+
+    w1 = tensor[0, 0, 0, 1]
+    w2 = tensor[0, 0, 0, 2]
+    w3 = tensor[0, 0, 0, 3]
+
+    simplex = np.concatenate((simplex, x1 * np.array([y1, y2, y3])))
+    simplex = np.concatenate((simplex, x2 * np.array([y1, y2])))
+    simplex = np.concatenate((simplex, np.array([x3 * y1])))
+
+    simplex = np.concatenate((simplex, x1 * np.array([z1, z2, z3])))
+    simplex = np.concatenate((simplex, x2 * np.array([z1, z2])))
+    simplex = np.concatenate((simplex, x3 * np.array([z1])))
+
+    simplex = np.concatenate((simplex, y1 * np.array([z1, z2, z3])))
+    simplex = np.concatenate((simplex, y2 * np.array([z1, z2])))
+    simplex = np.concatenate((simplex, y3 * np.array([z1])))
+
+    simplex = np.concatenate((simplex, x1 * np.array([w1, w2, w3])))
+    simplex = np.concatenate((simplex, x2 * np.array([w1, w2])))
+    simplex = np.concatenate((simplex, x3 * np.array([w1])))
+
+    simplex = np.concatenate((simplex, y1 * np.array([w1, w2, w3])))
+    simplex = np.concatenate((simplex, y2 * np.array([w1, w2])))
+    simplex = np.concatenate((simplex, y3 * np.array([w1])))
+
+    simplex = np.concatenate((simplex, z1 * np.array([w1, w2, w3])))
+    simplex = np.concatenate((simplex, z2 * np.array([w1, w2])))
+    simplex = np.concatenate((simplex, z3 * np.array([w1])))
+
+    simplex = np.concatenate((simplex, x1 * np.array([y1*z1, y1*z2])))
+    simplex = np.concatenate((simplex, x2 * np.array([y1*z1])))
+    simplex = np.concatenate((simplex, x1 * np.array([y2*z1])))
+
+    simplex = np.concatenate((simplex, x1 * np.array([y1*w1, y1*w2])))
+    simplex = np.concatenate((simplex, x2 * np.array([y1*w1])))
+    simplex = np.concatenate((simplex, x1 * np.array([y2*w1])))
+
+    simplex = np.concatenate((simplex, x1 * np.array([z1*w1, z1*w2])))
+    simplex = np.concatenate((simplex, x2 * np.array([z1*w1])))
+    simplex = np.concatenate((simplex, y1 * np.array([z1*w1, z1*w2])))
+
+    simplex = np.concatenate((simplex, y2 * np.array([z1*w1])))
+    simplex = np.concatenate((simplex, x1 * np.array([z2*w1])))
+    simplex = np.concatenate((simplex, y1 * np.array([z2*w1])))
+
+    simplex = np.concatenate((simplex, x1 * np.array([y1*z1*w1])))
+
+    return simplex

--- a/mdp/test/test_RecursiveExpansionNode.py
+++ b/mdp/test/test_RecursiveExpansionNode.py
@@ -3,7 +3,9 @@ Tests for the RecursiveExpansionNode.
 """
 
 from mdp.nodes import PolynomialExpansionNode
-from mdp.nodes import RecursiveExpansionNode
+from mdp.nodes import (RecursiveExpansionNode,
+                       TrainableRecursiveExpansionNode)
+from mdp.nodes.recursive_expansion_nodes import recfs
 from mdp.test._tools import *
 from mdp import numx as np
 import py.test

--- a/mdp/test/test_RecursiveExpansionNode.py
+++ b/mdp/test/test_RecursiveExpansionNode.py
@@ -4,7 +4,7 @@ Tests for the RecursiveExpansionNode.
 
 from mdp.nodes import PolynomialExpansionNode
 from mdp.nodes import (RecursiveExpansionNode,
-                       TrainableRecursiveExpansionNode)
+                       NormalizingRecursiveExpansionNode)
 from mdp.nodes.recursive_expansion_nodes import recfs
 from mdp.test._tools import *
 from mdp import numx as np

--- a/mdp/test/test_TrainableRecursiveExpansionNode.py
+++ b/mdp/test/test_TrainableRecursiveExpansionNode.py
@@ -1,0 +1,29 @@
+"""
+Tests for the TrainableRecursiveExpansionNode.
+"""
+
+from mdp.nodes import (RecursiveExpansionNode,
+                       TrainableRecursiveExpansionNode)
+from mdp.nodes.recursive_expansion_nodes import recfs
+from mdp.test._tools import *
+from mdp import numx as np
+import py.test
+
+
+def test_TrainableRecursiveExpansionNode():
+    """Essentially testing the domain transformation."""
+    degree = 10
+    episodes = 5
+    num_obs = 500
+    num_vars = 4
+
+    for func_name in recfs:
+        x = np.zeros((0, num_vars))
+        expn = TrainableRecursiveExpansionNode(degree, recf=func_name,
+                                               check=True, with0=True)
+        for i in range(episodes):
+            chunk = (np.random.rand(num_obs, num_vars)-0.5)*1000
+            expn.train(chunk)
+            x = np.concatenate((x, chunk), axis=0)
+        expn.stop_training()
+        expn.execute(x)


### PR DESCRIPTION
Dear MDP developers,

I am happy to share the code of a new node to be considered for inclusion into MDP. The RecursiveExpansionNode implements recursion formulas for (orthogonal or linearly independend) sequences of functions, such as standard polynomials, Legendre polynomials, Legendre rational functions and Chebyshev polynomials of first kind. It can be extended easily to other recursions. Furthermore, an efficient way of computing multivariate expansions is employed.

In a following commit, a trainable version of this node is to be included. The Node was jointly developed by Stefan Richthofer and me.


