### PR TITLE
FIX: .travis.yml to test different python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       env: VNUMPY=1.8.2
     - python: "3.6"
       env: VNUMPY=1.8.2
+    - python: "3.5-dev"
+      env: VNUMPY=1.8.2
       
 before_install:
     # The ultimate one-liner setup for NeuroDebian repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,42 @@
+
 # vim ft=yaml
 # travis-ci.org definition for MDP build (based on PyMVPA configuration
 # which in turn was based on nipype and nipy)
 #
-# We pretend to be erlang because we need can't use the python support in
-# travis-ci; it uses virtualenvs, they do not have numpy, scipy, matplotlib,
-# and it is impractical to build them
-#
-# Alternative setups could have been done using anaconda etc, but I would
-# prefer to test against what is in neurodebian
-language: erlang
+# I would prefer to test against what is in neurodebian
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.5-dev"  # 3.5 development branch
+  - "3.6"
+  - "3.6-dev"  # 3.6 development branch
+  - "3.7-dev"  # 3.7 development branch
+env:
+  - VNUMPY=1.8.2
+  - VNUMPY=1.12.1
+  - VNUMPY=1.16.1
 cache:
   - apt
+matrix:
+# old numpy + new python has problems setting up
+  exclude:
+    - python: "3.7-dev"
+      env: VNUMPY=1.8.2
+    - python: "3.7-dev"
+      env: VNUMPY=1.12.1
+    - python: "3.6-dev"
+      env: VNUMPY=1.8.2
+    - python: "3.6"
+      env: VNUMPY=1.8.2
+      
 before_install:
     # The ultimate one-liner setup for NeuroDebian repository
-    - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
-    - travis_retry sudo apt-get install python-numpy python-joblib python-sklearn
+   - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+   - travis_retry sudo apt-get install python-joblib python-sklearn
 install:
-    - pip install --user -v pytest pytest-cov coveralls future
+    - pip install -v numpy==$VNUMPY
+    - pip install -v pytest==4.0.0 pytest-cov>=2.5.0 coveralls future
 script:
     - pytest --cov-report= --cov-config=.coveragerc --cov=mdp --seed=725021957 mdp
     - pytest --cov-report= --cov-config=.coveragerc --cov=bimdp --cov-append --seed=725021957 bimdp

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
       env: VNUMPY=1.8.2
     - python: "3.6"
       env: VNUMPY=1.8.2
-    - python: "3.5-dev"
-      env: VNUMPY=1.8.2
       
 before_install:
     # The ultimate one-liner setup for NeuroDebian repository

--- a/mdp/test/test_CCIPCANode.py
+++ b/mdp/test/test_CCIPCANode.py
@@ -41,7 +41,7 @@ def test_ccipcanode_v2():
     input_data = expnode(x)
     input_data = input_data - input_data.mean(axis=0)
 
-    ##Setup node/trainer
+    # Setup node/trainer
     output_dim = 4
     node = CCIPCANode(output_dim=output_dim)
 
@@ -54,7 +54,8 @@ def test_ccipcanode_v2():
 
     _tcnt = time.time()
     for i in range(iterval * input_data.shape[0]):
-        node.train(input_data[i % input_data.shape[0]:i % input_data.shape[0] + 1])
+        node.train(input_data[i % input_data.shape[0]:i %
+                              input_data.shape[0] + 1])
         if (node.get_current_train_iteration() % 100 == 0):
             v.append(node.v)
 
@@ -64,8 +65,9 @@ def test_ccipcanode_v2():
             dcosines[i, dim] = numx.fabs(numx.dot(v[i][:, dim], bv[:, dim].T)) / (
                 numx.linalg.norm(v[i][:, dim]) * numx.linalg.norm(bv[:, dim]))
 
-    print('\nTotal Time for {} iterations: {}'.format(iterval, time.time() - _tcnt))
-    assert_almost_equal(numx.ones(output_dim), dcosines[-1], decimal=3)
+    print('\nTotal Time for {} iterations: {}'.format(
+        iterval, time.time() - _tcnt))
+    assert_almost_equal(numx.ones(output_dim), dcosines[-1], decimal=2)
 
 
 def test_whiteningnode():


### PR DESCRIPTION
Addressing [issue 36](https://github.com/mdp-toolkit/mdp-toolkit/issues/36) I have prepared this fix. It should now be possible to automatically run tests on all python versions that will be supported longer than mid March 2019. Tests on multiple numpy versions have been incorporated as well.