### PR TITLE
Fix for "DeprecationWarning: inspect.getargspec() is deprecated"

### DIFF
--- a/mdp/parallel/parallelnodes.py
+++ b/mdp/parallel/parallelnodes.py
@@ -11,7 +11,11 @@ from builtins import str
 # http://projects.scipy.org/scipy/numpy/ticket/551
 # To circumvent this, you can use a copy() of all unpickled arrays.
 
-import inspect
+# python 2/3 compatibility
+try:
+    from inspect import getfullargspec as getargs
+except ImportError:
+    from inspect import getargspec as getargs
 
 import mdp
 from mdp import numx
@@ -47,7 +51,7 @@ class ParallelExtensionNode(mdp.ExtensionNode, mdp.Node):
     # TODO: allow that forked nodes are not forkable themselves,
     #    and are not joinable either
     #    this implies that caching does not work for these
-    
+
     def fork(self):
         """Return a new instance of this node class for remote training.
 
@@ -95,19 +99,19 @@ class ParallelExtensionNode(mdp.ExtensionNode, mdp.Node):
         raise JoinParallelException("join is not implemented " +
                                     "by this node (%s)" %
                                     str(self.__class__))
-    
+
     @staticmethod
     def use_execute_fork():
         """Return True if node requires a fork / join even during execution.
-        
+
         The default output is False, overwrite this method if required.
-        
+
         Note that the same fork and join methods are used as during training,
         so the distinction must be implemented in the custom _fork and _join
         methods.
         """
         return False
-    
+
     ## helper methods ##
 
     def _default_fork(self):
@@ -119,7 +123,7 @@ class ParallelExtensionNode(mdp.ExtensionNode, mdp.Node):
 
         So you can use this method if all the required keys are also public
         attributes or have a single underscore in front.
-        
+
         There are two reasons why this method does not simply replace _fork
         of ParallelExtensionNode (plus removing Node from the
         inheritance list):
@@ -132,7 +136,7 @@ class ParallelExtensionNode(mdp.ExtensionNode, mdp.Node):
             relying on the inherited (but possibly incompatible)
             default implementation.
         """
-        args, varargs, varkw, defaults = inspect.getargspec(self.__init__)
+        args, varargs, varkw, defaults = getargs(self.__init__)[:4]
         args.remove("self")
         if defaults:
             non_default_keys = args[:-len(defaults)]
@@ -157,18 +161,18 @@ class ParallelExtensionNode(mdp.ExtensionNode, mdp.Node):
                 raise NotForkableParallelException(err)
         # create new instance
         return self.__class__(**kwargs)
-    
+
     @staticmethod
     def _join_covariance(cov, forked_cov):
         """Helper method to join two CovarianceMatrix instances.
-        
+
         cov -- Instance of CovarianceMatrix, to which the forked_cov instance
             is aded in-place.
         """
         cov._cov_mtx += forked_cov._cov_mtx
         cov._avg += forked_cov._avg
         cov._tlen += forked_cov._tlen
-        
+
 
 ## MDP parallel node implementations ##
 
@@ -248,6 +252,6 @@ class ParallelHistogramNode(ParallelExtensionNode, mdp.nodes.HistogramNode):
     def _join(self, forked_node):
         if (self.data_hist is not None) and (forked_node.data_hist is not None):
             self.data_hist = numx.concatenate([self.data_hist,
-                                            forked_node.data_hist])
+                                               forked_node.data_hist])
         elif forked_node.data_hist is not None:
             self.data_hist = forked_node.data_hist

--- a/mdp/signal_node.py
+++ b/mdp/signal_node.py
@@ -10,6 +10,11 @@ __docformat__ = "restructuredtext en"
 import pickle as _cPickle
 import warnings as _warnings
 import copy as _copy
+# python 2/3 compatibility
+try:
+    from inspect import getfullargspec as getargs
+except ImportError:
+    from inspect import getargspec as getargs
 import inspect
 
 import mdp
@@ -162,7 +167,7 @@ class NodeMetaclass(type):
         >>> info["kwargs_name"]
         kw
         """
-        regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
+        regargs, varargs, varkwargs, defaults = getargs(func)[:4]
         argnames = list(regargs)
         if varargs:
             argnames.append(varargs)

--- a/mdp/test/test_metaclass_and_extensions.py
+++ b/mdp/test/test_metaclass_and_extensions.py
@@ -1,13 +1,20 @@
 
 import mdp
+# python 2/3 compatibility
+try:
+    from inspect import getfullargspec as getargs
+except ImportError:
+    from inspect import getargspec as getargs
 import inspect
 import pytest
-X = mdp.numx_rand.random(size=(500,5))
+X = mdp.numx_rand.random(size=(500, 5))
+
 
 def get_signature(func):
-    regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
+    regargs, varargs, varkwargs, defaults = getargs(func)[:4]
     return inspect.formatargspec(regargs, varargs, varkwargs, defaults,
                                  formatvalue=lambda value: "")[1:-1]
+
 
 def teardown_function(function):
     """Deactivate all extensions and remove testing extensions."""
@@ -16,10 +23,12 @@ def teardown_function(function):
         if key.startswith("__test"):
             del mdp.get_extensions()[key]
 
+
 def test_signatures_same_no_arguments():
     class AncestorNode(mdp.Node):
         def _train(self, x, foo2=None):
             self.foo2 = None
+
     class ChildNode(AncestorNode):
         def _train(self, x, foo=None):
             self.foo = foo
@@ -30,22 +39,26 @@ def test_signatures_same_no_arguments():
     assert cnode.foo == 42
     pytest.raises(AttributeError, 'cnode.foo2')
 
+
 def test_signatures_more_arguments():
     class AncestorNode(mdp.Node):
         def _train(self, x):
             self.foo2 = None
+
     class ChildNode(AncestorNode):
         def _train(self, x, foo=None):
             self.foo = foo
     cnode = ChildNode()
     assert get_signature(cnode.train) == 'self, x, foo'
-    assert get_signature(cnode.train._undecorated_) == 'self, x, *args, **kwargs'
+    assert get_signature(
+        cnode.train._undecorated_) == 'self, x, *args, **kwargs'
     assert get_signature(cnode._train) == 'self, x, foo'
     # next two lines should give the same:
     cnode.train._undecorated_(cnode, X, foo=42)
     cnode.train(X, foo=42)
     assert cnode.foo == 42
     pytest.raises(AttributeError, 'cnode.foo2')
+
 
 def test_signatures_less_arguments():
 
@@ -59,7 +72,8 @@ def test_signatures_less_arguments():
 
     cnode = ChildNode()
     assert get_signature(cnode.train) == 'self, x'
-    assert get_signature(cnode.train._undecorated_) == 'self, x, *args, **kwargs'
+    assert get_signature(
+        cnode.train._undecorated_) == 'self, x, *args, **kwargs'
     assert get_signature(cnode._train) == 'self, x'
 
     # next two lines should give the same:
@@ -68,10 +82,12 @@ def test_signatures_less_arguments():
     assert cnode.moo == 3
     pytest.raises(AttributeError, 'cnode.foo')
 
+
 def test_simple_extension():
 
     class TestExtensionNode(mdp.ExtensionNode, mdp.nodes.IdentityNode):
         extension_name = "__test"
+
         def execute(self, x):
             self.foo = 42
             return self._non_extension_execute(x)
@@ -82,16 +98,16 @@ def test_simple_extension():
 
     node = mdp.nodes.IdentityNode()
     assert mdp.numx.all(node.execute(X) == X)
-    assert not hasattr(node,'foo')
+    assert not hasattr(node, 'foo')
 
     with mdp.extension("__test"):
         assert mdp.numx.all(node.execute(X) == X)
-        assert hasattr(node,'foo')
+        assert hasattr(node, 'foo')
 
     node = Dummy()
-    assert not hasattr(node,'foo')
+    assert not hasattr(node, 'foo')
     assert node.execute(X) == 42
 
     with mdp.extension("__test"):
         assert node.execute(X) == 42
-        assert hasattr(node,'foo')
+        assert hasattr(node, 'foo')

--- a/mdp/test/test_node_metaclass.py
+++ b/mdp/test/test_node_metaclass.py
@@ -1,12 +1,20 @@
 
 import mdp
+# python 2/3 compatibility
+try:
+    from inspect import getfullargspec as getargs
+except ImportError:
+    from inspect import getargspec as getargs
 import inspect
-X = mdp.numx_rand.random(size=(500,5))
+
+X = mdp.numx_rand.random(size=(500, 5))
+
 
 def get_signature(func):
-    regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
+    regargs, varargs, varkwargs, defaults = getargs(func)[:4]
     return inspect.formatargspec(regargs, varargs, varkwargs, defaults,
                                  formatvalue=lambda value: "")[1:-1]
+
 
 def test_docstrings():
     # first try on a subclass of Node if
@@ -21,8 +29,8 @@ def test_docstrings():
     assert anode.foo == 42
     assert get_signature(anode.train) == 'self, x'
 
-
     # now try on a subclass of it
+
     class ChildNode(AncestorNode):
         def _train(self, x):
             """doc child"""
@@ -32,6 +40,7 @@ def test_docstrings():
     cnode.train(X)
     assert cnode.foo2 == 42
     assert get_signature(cnode.train) == 'self, x'
+
 
 def test_signatures_no_doc():
     # first try on a subclass of Node if
@@ -43,7 +52,7 @@ def test_signatures_no_doc():
     anode.train(X, foo='abc')
     assert anode.foo == 42
     assert get_signature(anode.train) == 'self, x, foo'
-    
+
     # now try on a subclass of it
     class ChildNode(AncestorNode):
         def _train(self, x, foo2=None):
@@ -52,6 +61,7 @@ def test_signatures_no_doc():
     cnode.train(X, foo2='abc')
     assert cnode.foo2 == 42
     assert get_signature(cnode.train) == 'self, x, foo2'
+
 
 def test_signatures_with_doc_in_both():
     # first try on a subclass of Node if
@@ -66,7 +76,7 @@ def test_signatures_with_doc_in_both():
     anode.train(X, foo='abc')
     assert anode.foo == 42
     assert get_signature(anode.train) == 'self, x, foo'
-    
+
     # now try on a subclass of it
     class ChildNode(AncestorNode):
         def _train(self, x, foo2=None):
@@ -77,6 +87,7 @@ def test_signatures_with_doc_in_both():
     cnode.train(X, foo2='abc')
     assert cnode.foo2 == 42
     assert get_signature(cnode.train) == 'self, x, foo2'
+
 
 def test_signatures_with_doc_in_ancestor():
     # first try on a subclass of Node if
@@ -101,6 +112,7 @@ def test_signatures_with_doc_in_ancestor():
     cnode.train(X, foo2='abc')
     assert cnode.foo2 == 42
     assert get_signature(cnode.train) == 'self, x, foo2'
+
 
 def test_signatures_with_doc_in_child():
     # first try on a subclass of Node if

--- a/mdp/test/test_nodes_generic.py
+++ b/mdp/test/test_nodes_generic.py
@@ -1,8 +1,12 @@
 from builtins import range
 from builtins import object
 import pytest
+# python 2/3 compatibility
+try:
+    from inspect import getfullargspec as getargs
+except ImportError:
+    from inspect import getargspec as getargs
 import inspect
-
 from mdp import (config, nodes, ClassifierNode,
                  PreserveDimNode, InconsistentDimException)
 from ._tools import *
@@ -233,7 +237,7 @@ def test_outputdim_consistency(klass, init_args, inp_arg_gen,
     # check if the node output dimension can be set or must be determined
     # by the node
     if (not issubclass(klass, PreserveDimNode) and
-            'output_dim' in inspect.getargspec(klass.__init__)[0]):
+            'output_dim' in getargs(klass.__init__)[0]):
         # case 1: output dim set in the constructor
         node = klass(output_dim=output_dim, *args)
         _test(node)
@@ -245,21 +249,21 @@ def test_outputdim_consistency(klass, init_args, inp_arg_gen,
     else:
         if issubclass(klass, PreserveDimNode):
             # check that constructor allows to set output_dim
-            assert 'output_dim' in inspect.getargspec(klass.__init__)[0]
+            assert 'output_dim' in getargs(klass.__init__)[0]
             # check that setting the input dim, then incompatible output dims
             # raises an appropriate error
             # case 1: both in the constructor
             pytest.raises(InconsistentDimException,
-                           'klass(input_dim=inp.shape[1], output_dim=output_dim, *args)')
+                          'klass(input_dim=inp.shape[1], output_dim=output_dim, *args)')
             # case 2: first input_dim, then output_dim
             node = klass(input_dim=inp.shape[1], *args)
             pytest.raises(InconsistentDimException,
-                           'node.output_dim = output_dim')
+                          'node.output_dim = output_dim')
             # case 3: first output_dim, then input_dim
             node = klass(output_dim=output_dim, *args)
             node.output_dim = output_dim
             pytest.raises(InconsistentDimException,
-                           'node.input_dim = inp.shape[1]')
+                          'node.input_dim = inp.shape[1]')
 
         # check that output_dim is set to whatever the output dim is
         node = klass(*args)


### PR DESCRIPTION
The fix adressing [issue 49](https://github.com/mdp-toolkit/mdp-toolkit/issues/49) was pretty straightforward and based on the suggested replacement "inspect.getfullargspec". The only complication I came across was python 2 requiring to use the old method. So I added a handling for the module level imports.