### PR TITLE
FIX for issue 50: Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,10 +75,14 @@ matrix:
       env: VNUMPY=1.8.2  VSCI=0.21.2
     - python: "3.5-dev"
       env: VNUMPY=1.8.2  VSCI=0.20.0
+    - python: "3.5-dev"
+      env: VNUMPY=1.8.2  VSCI=0.18
     - python: "3.5"
       env: VNUMPY=1.8.2  VSCI=0.21.2
     - python: "3.5"
       env: VNUMPY=1.8.2  VSCI=0.20.0
+    - python: "3.5"
+      env: VNUMPY=1.8.2  VSCI=0.18
 
       
       


### PR DESCRIPTION
It is not explicitly stated, which Python versions are supported by Numpy 1.8.2, but Numpy 1.8.0 supports only 2.6 -2.7/3.2 - 3.3 and Numpy 1.9.0 supports only 2.6 - 2.7 and 3.2 - 3.4 [1]. So I propose to exclude testing on this version combination to address [issue 50](https://github.com/mdp-toolkit/mdp-toolkit/issues/50).

[1] https://docs.scipy.org/doc/numpy/release.html