### PR TITLE
Fully exclude the officially unsupported combination Python 3.8 + scikits 0.21.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "3.6-dev"  # 3.6 development branch
   - "3.7"
   - "3.7-dev"  # 3.7 development branch
-  - "3.8.0"
+  - "3.8"
   - "3.8-dev"  # 3.8 development branch
 env:
   - VNUMPY=1.12.1  VSCI=0.22
@@ -60,30 +60,32 @@ matrix:
     - python: "3.8-dev"
       env: VNUMPY=1.16.1  VSCI=0.18
     - python: "3.8-dev"
+      env: VNUMPY=1.17.4  VSCI=0.21.3
+    - python: "3.8-dev"
       env: VNUMPY=1.17.4  VSCI=0.20.0
     - python: "3.8-dev"
       env: VNUMPY=1.17.4  VSCI=0.18
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.12.1  VSCI=0.22
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.12.1  VSCI=0.21.3
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.12.1  VSCI=0.20.0
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.12.1  VSCI=0.18
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.16.1  VSCI=0.22
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.16.1  VSCI=0.21.3
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.16.1  VSCI=0.20.0
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.16.1  VSCI=0.18
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.17.4  VSCI=0.21.3
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.17.4  VSCI=0.20.0
-    - python: "3.8.0"
+    - python: "3.8"
       env: VNUMPY=1.17.4  VSCI=0.18
     - python: "3.7-dev"
       env: VNUMPY=1.12.1  VSCI=0.22

--- a/README
+++ b/README
@@ -1,1 +1,3 @@
-Please refer to the online documentation at http://mdp-toolkit.sourceforge.net
+Please refer to the online documentation at https://mdpdocs.readthedocs.io
+The legacy documentation is still available at http://mdp-toolkit.sourceforge.net
+


### PR DESCRIPTION
It was kept because it worked under Python 3.8-dev but that turned out to be cumbersome, travis needs over 9 min to complete it, 7 minutes of this being strange setup stuff.