### PR TITLE
ERF: adapt directive to work with epydoc

### DIFF
--- a/mdp/nodes/convolution_nodes.py
+++ b/mdp/nodes/convolution_nodes.py
@@ -22,9 +22,7 @@ class Convolution2DNode(mdp.Node):
     
     This node depends on ``scipy``.
     
-    .. attribute:: filters
-        
-        Specifies a set of 2D filters that are
+    :ivar filters: Specifies a set of 2D filters that are
         convolved with the input data during execution. 
 
     """

--- a/mdp/nodes/em_nodes.py
+++ b/mdp/nodes/em_nodes.py
@@ -29,22 +29,14 @@ class FANode(mdp.Node):
     of the latent variables. The ``generate_input`` method generates
     observations from the prior distribution.
 
-    .. attribute:: mu
-    
-          Mean of the input data (available after training)
+    :ivar mu: Mean of the input data (available after training).
 
-    .. attribute:: A
-    
-          Generating weights (available after training)
+    :ivar A: Generating weights (available after training).
 
-    .. attribute:: E_y_mtx
-    
-          Weights for Maximum A Posteriori inference
+    :ivar E_y_mtx: Weights for Maximum A Posteriori inference.
 
-    .. attribute:: sigma
-    
-          Vector of estimated variance of the noise
-          for all input components
+    :ivar sigma: Vector of estimated variance of the noise
+        for all input components.
     
     |
     

--- a/mdp/nodes/fda_nodes.py
+++ b/mdp/nodes/fda_nodes.py
@@ -24,13 +24,9 @@ class FDANode(mdp.Node):
           called just once as usual, since it takes care of *rewinding* the iterator
           to perform the second training step.
 
-    .. attribute:: avg
-      
-        Mean of the input data (available after training)
+    :ivar avg:  Mean of the input data (available after training).
 
-    .. attribute:: v
-      
-        Transposed of the projection matrix, so that
+    :ivar v: Transposed of the projection matrix, so that
         ``output = dot(input-self.avg, self.v)`` (available after training).
           
     .. admonition:: Reference

--- a/mdp/nodes/ica_nodes.py
+++ b/mdp/nodes/ica_nodes.py
@@ -225,18 +225,12 @@ class CuBICANode(ICANode):
     As an alternative to this batch mode you might consider the telescope
     mode (see the docs of the ``__init__`` method).
     
-    .. attribute:: white
-     
-        The whitening node used for preprocessing.
+    :ivar white: The whitening node used for preprocessing.
 
-    .. attribute:: filters
-
-        The ICA filters matrix (this is the transposed of the
+    :ivar filters: The ICA filters matrix (this is the transposed of the
         projection matrix after whitening).
 
-    .. attribute:: convergence
-     
-        The value of the convergence threshold.
+    :ivar convergence: The value of the convergence threshold.
         
     .. admonition:: Reference
     
@@ -373,18 +367,12 @@ class FastICANode(ICANode):
         - 26.6.2006 converted to numpy
         - 14.9.2007 updated to Matlab version 2.5
 
-    .. attribute:: white
-    
-        The whitening node used for preprocessing.
+    :ivar white: The whitening node used for preprocessing.
 
-    .. attribute:: filters
-    
-        The ICA filters matrix (this is the transposed of the
+    :ivar filters: The ICA filters matrix (this is the transposed of the
         projection matrix after whitening).
 
-    .. attribute:: convergence
-    
-        The value of the convergence threshold.
+    :ivar convergence: The value of the convergence threshold.
         
     .. admonition:: Reference
     
@@ -1041,18 +1029,12 @@ class TDSEPNode(ISFANode, ProjectMatrixMixin):
         i.e. it is suited to be trained on huge data sets, provided that the
         training is done sending small chunks of data for each time.
 
-    .. attribute:: white
-    
-        The whitening node used for preprocessing.
+    :ivar white: The whitening node used for preprocessing.
 
-    .. attribute:: filters
-    
-        The ICA filters matrix (this is the transposed of the
+    :ivar filters: The ICA filters matrix (this is the transposed of the
         projection matrix after whitening).
 
-    .. attribute:: convergence
-    
-        The value of the convergence threshold.
+    :ivar convergence: The value of the convergence threshold.
            
     .. admonition:: Reference
     

--- a/mdp/nodes/isfa_nodes.py
+++ b/mdp/nodes/isfa_nodes.py
@@ -41,20 +41,14 @@ class ISFANode(Node):
     """
     Perform Independent Slow Feature Analysis on the input data.
 
-    .. attribute:: RP
-    
-        The global rotation-permutation matrix. This is the filter
+    :ivar RP: The global rotation-permutation matrix. This is the filter
         applied on input_data to get output_data
 
-    .. attribute:: RPC
-    
-        The *complete* global rotation-permutation matrix. This
+    :ivar RPC: The *complete* global rotation-permutation matrix. This
         is a matrix of dimension input_dim x input_dim (the 'outer space'
         is retained)
 
-    .. attribute:: covs
-    
-        A `mdp.utils.MultipleCovarianceMatrices` instance 
+    :ivar covs: A `mdp.utils.MultipleCovarianceMatrices` instance 
         input_data. After convergence the uppermost
         ``output_dim`` x ``output_dim`` submatrices should be almost
         diagonal.
@@ -68,14 +62,10 @@ class ISFANode(Node):
         
             >>> del self.covs
 
-    .. attribute:: initial_contrast
-    
-        A dictionary with the starting contrast and the
+    :ivar initial_contrast: A dictionary with the starting contrast and the
         SFA and ICA parts of it.
 
-    .. attribute:: final_contrast
-    
-        Like the above but after convergence.
+    :ivar final_contrast: Like the above but after convergence.
 
     .. note::
     

--- a/mdp/nodes/libsvm_classifier.py
+++ b/mdp/nodes/libsvm_classifier.py
@@ -18,12 +18,9 @@ class LibSVMClassifier(_SVMClassifier):
     
     The class provides access to change kernel and svm type with a text string.
     
-    .. attribute:: parameter
-    
-        Allows to change all other svm parameters directly.
+    :ivar parameter: Allows to change all other svm parameters directly.
         
-    .. attribute:: kernels
-    
+    :ivar kernels: 
         Kernels which LibSVM allows:
 			
 		- 'RBF' - Radial basis function kernel
@@ -31,8 +28,7 @@ class LibSVMClassifier(_SVMClassifier):
 		- 'POLY' - Polynomial kernel
 		- 'SIGMOID' - Sigmoid kernel
     
-    .. attribute:: classifiers
-    
+    :ivar classifiers:    
         Classifiers which LibSVM allows:
 
 		- 'C_SVC'

--- a/mdp/nodes/lle_nodes.py
+++ b/mdp/nodes/lle_nodes.py
@@ -21,14 +21,11 @@ sqrt = numx.sqrt
 class LLENode(Cumulator):
     """Perform a Locally Linear Embedding analysis on the data.
 
-    .. attribute:: training_projection
-    
-          The LLE projection of the training data (defined when
-          training finishes).
+    :ivar training_projection: The LLE projection of the training data
+        (defined when training finishes).
 
-    .. attribute:: desired_variance
-    
-          Variance limit used to compute intrinsic dimensionality.
+    :ivar desired_variance: Variance limit used to compute intrinsic
+        dimensionality.
 
     Based on the algorithm outlined in *An Introduction to Locally
     Linear Embedding* by L. Saul and S. Roweis, using improvements
@@ -351,14 +348,11 @@ def _mgs(a):
 class HLLENode(LLENode):
     """Perform a Hessian Locally Linear Embedding analysis on the data.
 
-    .. attribute:: training_projection
-    
-          The HLLE projection of the training data (defined when training
-          finishes)
+    :ivar training_projection: The HLLE projection of the training data
+        (defined when training finishes).
 
-    .. attribute:: desired_variance
-    
-          Variance limit used to compute intrinsic dimensionality.
+    :ivar desired_variance: Variance limit used to compute intrinsic
+        dimensionality.
     
     |
     

--- a/mdp/nodes/mca_nodes_online.py
+++ b/mdp/nodes/mca_nodes_online.py
@@ -9,13 +9,9 @@ class MCANode(mdp.OnlineNode):
     Minor Component Analysis (MCA) extracts minor components (dual of principal
     components) from the input data incrementally.
 
-    .. attribute:: v
-    
-         Eigen vectors
+    :ivar v: Eigenvectors
 
-    .. attribute:: d
-    
-         Eigen values
+    :ivar d: Eigenvalues
     
     |
     

--- a/mdp/nodes/neural_gas_nodes.py
+++ b/mdp/nodes/neural_gas_nodes.py
@@ -53,9 +53,7 @@ class GrowingNeuralGasNode(Node):
     if the growth rate is appropriate, one can avoid overfitting  or
     underfitting the data.
 
-    .. attribute:: graph
-    
-        The corresponding `mdp.graph.Graph` object.
+    :ivar graph: The corresponding `mdp.graph.Graph` object.
     
     |
     
@@ -320,13 +318,9 @@ class NeuralGasNode(GrowingNeuralGasNode):
     """Learn the topological structure of the input data by building a
     corresponding graph approximation (original Neural Gas algorithm).
 
-    .. attribute:: graph
-     
-        The corresponding `mdp.graph.Graph` object.
+    :ivar graph: The corresponding `mdp.graph.Graph` object.
     
-    .. attribute:: max_epochs
-        
-        Maximum number of epochs until which to train.
+    :ivar max_epochs: Maximum number of epochs until which to train.
     
     |
     

--- a/mdp/nodes/nipals.py
+++ b/mdp/nodes/nipals.py
@@ -18,23 +18,15 @@ class NIPALSNode(Cumulator, PCANode):
     principal components to be a small. In this case setting output_dim to be
     a certain fraction of the total variance, say 90%, may be of some help.
 
-    .. attribute:: avg
-    
-          Mean of the input data (available after training).
+    :ivar avg: Mean of the input data (available after training).
 
-    .. attribute:: d
-    
-          Variance corresponding to the PCA components.
+    :ivar d: Variance corresponding to the PCA components.
 
-    .. attribute:: v
-    
-          Transposed of the projection matrix (available after training).
+    :ivar v: Transposed of the projection matrix (available after training).
           
-    .. attribute:: explained_variance
-    
-          When output_dim has been specified as a fraction of the total
-          variance, this is the fraction of the total variance that is actually
-          explained.
+    :ivar explained_variance: When output_dim has been specified as a fraction
+        of the total variance, this is the fraction of the total variance that is
+        actually explained.
     
     |
     

--- a/mdp/nodes/pca_nodes.py
+++ b/mdp/nodes/pca_nodes.py
@@ -14,23 +14,15 @@ class PCANode(mdp.Node):
     """Filter the input data through the most significatives of its
     principal components.
     
-    .. attribute:: avg
-    
-        Mean of the input data (available after training).
+    :ivar avg: Mean of the input data (available after training).
         
-    .. attribute:: v
-    
-        Transposed of the projection matrix (available after training).
+    :ivar v: Transposed of the projection matrix (available after training).
 
-    .. attribute:: d
-    
-        Variance corresponding to the PCA components (eigenvalues of the
+    :ivar d: Variance corresponding to the PCA components (eigenvalues of the
         covariance matrix).
 
-    .. attribute:: explained_variance
-    
-        When output_dim has been specified as a fraction of the total
-        variance, this is the fraction of the total variance that is
+    :ivar explained_variance: When output_dim has been specified as a fraction
+        of the total variance, this is the fraction of the total variance that is
         actually explained.
     
     |
@@ -386,22 +378,14 @@ class WhiteningNode(PCANode):
         
         All output signals have zero mean, unit variance and are decorrelated.
 
-        .. attribute:: avg
-        
-            Mean of the input data (available after training).
+        :ivar avg: Mean of the input data (available after training).
             
-        .. attribute:: v
-        
-            Transpose of the projection matrix (available after training).
+        :ivar v: Transpose of the projection matrix (available after training).
 
-        .. attribute:: d
-        
-            Variance corresponding to the PCA components (eigenvalues of
+        :ivar d: Variance corresponding to the PCA components (eigenvalues of
             the covariance matrix).
 
-        .. attribute:: explained_variance
-        
-            When output_dim has been specified as a 
+        :ivar explained_variance: When output_dim has been specified as a 
             fraction of the total variance, this is the fraction of the total
             variance that is actually explained.
         """

--- a/mdp/nodes/pca_nodes_online.py
+++ b/mdp/nodes/pca_nodes_online.py
@@ -9,13 +9,9 @@ class CCIPCANode(mdp.OnlineNode):
     Candid-Covariance free Incremental Principal Component Analysis (CCIPCA)
     extracts the principal components from the input data incrementally.
     
-    .. attribute:: v
-    
-        Eigen vectors
+    :ivar v: Eigenvectors
 
-    .. attribute:: d
-        
-        Eigen values
+    :ivar d: Eigenvalues
     
     |
     

--- a/mdp/nodes/rbm_nodes.py
+++ b/mdp/nodes/rbm_nodes.py
@@ -51,17 +51,11 @@ class RBMNode(mdp.Node):
         Hinton, G. E. (2002). Training products of experts by minimizing
         contrastive divergence. Neural Computation, 14(8):1711-1800
 
-    .. attribute:: w
+    :ivar w: Generative weights between hidden and observed variables.
 
-        Generative weights between hidden and observed variables.
+    :ivar bv: Bias vector of the observed variables.
 
-    .. attribute:: bv
-
-        Bias vector of the observed variables.
-
-    .. attribute:: bh
-
-        Bias vector of the hidden variables.
+    :ivar bh: Bias vector of the hidden variables.
     """
 
     def __init__(self, hidden_dim, visible_dim = None, dtype = None):
@@ -307,18 +301,11 @@ class RBMWithLabelsNode(RBMNode):
           algorithm for deep belief nets. Neural Computation, 18:1527-1554.
 
 
-    .. attribute:: w
+    :ivar w: Generative weights between hidden and observed variables.
 
-        Generative weights between hidden and observed variables.
+    :ivar bv: Bias vector of the observed variables.
 
-    .. attribute:: bv
-
-        Bias vector of the observed variables.
-
-    .. attribute:: bh
-
-        Bias vector of the hidden variables.
-
+    :ivar bh: Bias vector of the hidden variables.
     """
 
     def __init__(self, hidden_dim, labels_dim, visible_dim=None, dtype=None):

--- a/mdp/nodes/recursive_expansion_nodes.py
+++ b/mdp/nodes/recursive_expansion_nodes.py
@@ -458,15 +458,11 @@ def process(off, leadVar, leadDeg, deg, pos, result, todoList):
 class RecursiveExpansionNode(_ExpansionNode):
     """Recursively computable (orthogonal) expansions.
 
-    .. attribute:: lower
+    :ivar lower: The lower bound of the domain on which the recursion function
+        is defined or orthogonal.
 
-        The lower bound of the domain on which the recursion function is
-        defined or orthogonal.
-
-    .. attribute:: upper
-
-        The upper bound of the domain on which the recursion function is
-        defined or orthogonal.
+    :ivar upper: The upper bound of the domain on which the recursion function
+        is defined or orthogonal.
     """
 
     def __init__(self, degree=1, recf='standard_poly', check=False,
@@ -633,14 +629,10 @@ class NormalizingRecursiveExpansionNode(RecursiveExpansionNode):
     """Recursively computable (orthogonal) expansions and a
     trainable transformation to the domain of the expansions.
 
-    .. attribute:: lower
-
-        The lower bound of the domain on which the recursion
+    :ivar lower: The lower bound of the domain on which the recursion
         function is defined or orthogonal.
 
-    .. attribute:: upper
-
-        The upper bound of the domain on which the recursion function
+    :ivar upper: The upper bound of the domain on which the recursion function
         is defined or orthogonal.
     """
 

--- a/mdp/nodes/regression_nodes.py
+++ b/mdp/nodes/regression_nodes.py
@@ -17,9 +17,7 @@ class LinearRegressionNode(Node):
     target data ``y`` to be supplied during training (see ``train``
     docstring).
 
-    .. attribute:: beta
-
-        The coefficients of the linear regression
+    :ivar beta: The coefficients of the linear regression.
     """
 
     def __init__(self, with_bias=True, use_pinv=False,

--- a/mdp/nodes/sfa_nodes.py
+++ b/mdp/nodes/sfa_nodes.py
@@ -46,17 +46,11 @@ There are several ways to deal with this issue:
 class SFANode(Node):
     """Extract the slowly varying components from the input data.
 
-    .. attribute:: avg
+    :ivar avg: Mean of the input data (available after training)
 
-        Mean of the input data (available after training)
+    :ivar sf: Matrix of the SFA filters (available after training)
 
-    .. attribute:: sf
-
-        Matrix of the SFA filters (available after training)
-
-    .. attribute:: d
-
-        Delta values corresponding to the SFA components (generalized
+    :ivar d: Delta values corresponding to the SFA components (generalized
         eigenvalues). [See the docs of the ``get_eta_values`` method for
         more information]
 
@@ -384,17 +378,11 @@ class VartimeSFANode(SFANode):
     In particular, this node numerically computes the integrals involved in
     the SFA problem formulation by applying the trapezoid rule.
 
-    .. attribute:: avg
+    :ivar avg: Mean of the input data (available after training)
 
-        Mean of the input data (available after training)
+    :ivar sf: Matrix of the SFA filters (available after training)
 
-    .. attribute:: sf
-
-        Matrix of the SFA filters (available after training)
-
-    .. attribute:: d
-
-        Delta values corresponding to the SFA components (generalized
+    :ivar d: Delta values corresponding to the SFA components (generalized
         eigenvalues). [See the docs of the ``get_eta_values`` method for
         more information]
 

--- a/mdp/nodes/sfa_nodes_online.py
+++ b/mdp/nodes/sfa_nodes_online.py
@@ -12,17 +12,11 @@ class IncSFANode(mdp.OnlineNode):
     components from the input data incrementally.
 
 
-    .. attribute:: sf
-    
-         Slow feature vectors
+    :ivar sf: Slow feature vectors
 
-    .. attribute:: wv
-    
-         Whitening vectors
+    :ivar wv: Whitening vectors
 
-    .. attribute:: sf_change
-    
-         Difference in slow features after update
+    :ivar sf_change: Difference in slow features after update
          
     .. admonition:: Reference
     

--- a/mdp/nodes/stats_nodes_online.py
+++ b/mdp/nodes/stats_nodes_online.py
@@ -20,10 +20,7 @@ class OnlineCenteringNode(mdp.PreserveDimOnlineNode):
         avg_n intuitively denotes a "window size". For a large avg_n, 'avg_n'-samples represent about 86% of
         the total weight.
 
-    .. attribute:: avg
-    
-        The updated average of the input data
-
+    :ivar avg: The updated average of the input data.
     """
 
     def __init__(self, avg_n=None, input_dim=None, output_dim=None, dtype=None, numx_rng=None):


### PR DESCRIPTION
I am proposing to adapt the directive ".. attribute:: atr" of the rst-docstring style to ":ivar atr:". As @Stewori pointed out, this directive works with Epydoc and lets us build the [legacy documentation](http://mdp-toolkit.sourceforge.net/api/index.html).

[Reference](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#info-field-lists)