### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mdp (3.6-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 21:01:38 +0000
+
 mdp (3.6-1) unstable; urgency=medium
 
   * New upstream release (Closes: #867515)
@@ -28,7 +34,7 @@ mdp (3.3+git19-g4ec2f29-1) unstable; urgency=medium
   * "New" upstream git snapshot
     - resolves FTBFS by a workaround of faulty unicode encoding in
       sklearn docstrings (Closes: #724146)
-  * debian/rules 
+  * debian/rules
     - run tests from within a corresponding tests directory
 
  -- Yaroslav Halchenko <debian@onerussian.com>  Mon, 29 Sep 2014 08:46:33 -0400
@@ -82,7 +88,7 @@ mdp (3.2+git28-g4243e9c-1) unstable; urgency=low
   * Updated git repo information in README.Debian-source
   * Added shogun-python-modular to Build-Depends now that it is available
     on all major platforms
-  * Updated debian-branch name in gbp.conf 
+  * Updated debian-branch name in gbp.conf
   * Upload sponsored by Yaroslav Halchenko
 
  -- Tiziano Zito <opossumnano@gmail.com>  Mon, 23 Jan 2012 09:43:30 +0100
@@ -193,4 +199,3 @@ mdp (2.1+svn20080122-1) unstable; urgency=low
   * Initial release (Closes: #461634)
 
  -- Yaroslav Halchenko <debian@onerussian.com>  Sat, 19 Jan 2008 16:41:20 -0500
-

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 mdp (3.6-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 21:01:38 +0000
 

--- a/debian/rules
+++ b/debian/rules
@@ -12,4 +12,3 @@ override_dh_auto_test:
 
 override_dh_installchangelogs:
 	dh_installchangelogs -k CHANGES
-

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/visit1985/mdp/issues
+Bug-Submit: https://github.com/visit1985/mdp/issues/new
+Repository: https://github.com/visit1985/mdp.git
+Repository-Browse: https://github.com/visit1985/mdp


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/mdp/465efdb1-5126-449c-93b6-9c69bc8f94d9.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/465efdb1-5126-449c-93b6-9c69bc8f94d9/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/465efdb1-5126-449c-93b6-9c69bc8f94d9/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/465efdb1-5126-449c-93b6-9c69bc8f94d9/diffoscope)).
