### PR TITLE
FIX: fix support for libsvm installed from upstream or from PyPI

### DIFF
--- a/mdp/nodes/libsvm_classifier.py
+++ b/mdp/nodes/libsvm_classifier.py
@@ -6,7 +6,12 @@ from mdp import numx
 
 from .svm_classifiers import _SVMClassifier, _LabelNormalizer
 
-import libsvm.svmutil as libsvmutil
+try:
+    # this is the namespace used by upstream libsvm and the Debian package
+    import svmutil as libsvmutil
+except ImportError:
+    # this is the namespace if libsvm is installed via PyPI
+    import libsvm.svmutil as libsvmutil
 
 class LibSVMClassifier(_SVMClassifier):
     """


### PR DESCRIPTION
Upstream libsvm <https://github.com/cjlin1/libsvm/> and the upstream repo
for the package on PyPI <https://github.com/ocampor/libsvm/issues/6> use
a different namespace: https://bugs.debian.org/958114 .

This commit fixes the detection of the libsvm library such that it works
for both installation ways, from PyPI or directly from upstream. The
python3-libsvm package in Debian is following upstream.

Fixes #82  