### PR TITLE
Install Newest Versions of Python Packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - sudo apt-get -y install cython3 gfortran libblas-dev liblapack-dev
 
 install:
-    - pip install $DEPS
+    - pip install --force-reinstall $DEPS
 
 script:
     - pytest --cov-report= --cov-config=.coveragerc --cov=mdp --seed=725021957 mdp


### PR DESCRIPTION
When no version for a package is specified, `pip` defaults to the newest available version. It seems an exception to this is the case when a requirement is already satisfied.

An example of this is given by the recent [Travis run](https://travis-ci.org/github/mdp-toolkit/mdp-toolkit/jobs/700398010#L365). Here we ran:

```bash
pip install numpy==1.16.2 scipy==1.1.0 scikit-learn==0.20.0 joblib==0.13.2 libsvm pytest pytest-cov coveralls future
```
which yields:
```bash
...
Requirement already satisfied: pytest in /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages (4.3.1)
...
```

Which results in this error:
```bash
pluggy.manager.PluginValidationError: Plugin 'pytest_cov' could not be loaded: (pytest 4.3.1 (/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages), Requirement.parse('pytest>=4.6'))!
```
I am proposing to fix this by adding the `--force-reinstall` option, which will reinstall all packages even if they are already up-to-date.