### PR TITLE
FIX: Deprecation of numpy.typeDict

### DIFF
--- a/mdp/utils/routines.py
+++ b/mdp/utils/routines.py
@@ -292,9 +292,8 @@ def get_dtypes(typecodes_key, _safe=True):
     return types
 
 
-_UNSAFE_DTYPES = [numx.typeDict[d] for d in
-                  ['float16', 'float96', 'float128', 'complex192', 'complex256']
-                  if d in numx.typeDict]
+_UNSAFE_DTYPES = [numx.dtype(d).type for d in
+                  ['float16', 'float128', 'complex256']]
 
 
 def nongeneral_svd(A, range=None, **kwargs):


### PR DESCRIPTION
This PR addresses #92.

The proposed alternative `numpy.sctypeDict` seems to be discouraged in https://github.com/numpy/numpy/issues/17585.

Based on our relatively shallow current usage of `numpy.typeDict`:
https://github.com/mdp-toolkit/mdp-toolkit/blob/300d288d75ac8495f7f4a0ef40cb71d4ff58a311/mdp/utils/routines.py#L295

I propose to replace `numpy.typeDict[d]` by the generic `numpy.dtype(d).type` as:
```python
# excluded the invalid inputs; see below
>>> [numpy.typeDict[d]==numpy.dtype(d).type for d in ['float16', 'float128', 'complex256']]
# [True, True, True]
```


This change to a function (as opposed to dictionary) has the downside of having to exclude the check:
https://github.com/mdp-toolkit/mdp-toolkit/blob/300d288d75ac8495f7f4a0ef40cb71d4ff58a311/mdp/utils/routines.py#L297

However, we learn that exactly 2 of the current 5 checks will return `false` in the most recent release of numpy as of 03/27/22:
```python
>>> 'float96' in numpy.typeDict or 'complex192' in numpy.typeDict
# False
>>> 'float16' in numpy.typeDict and 'float128' in numpy.typeDict and 'complex256' in numpy.typeDict
# True
>>> numpy.__version__
# '1.22.3'
```
I excluded the invalid ones and dropped the check. I think it is likely this will not create problems down the line.

**General note:**
I am not sure the functionality of checking for unsafe types generically is still up-to-date. Especially as it is only run if one is not using `scipy.linalg.eigh`:
https://github.com/mdp-toolkit/mdp-toolkit/blob/300d288d75ac8495f7f4a0ef40cb71d4ff58a311/mdp/utils/routines.py#L286
