### PR TITLE
FIX: Deprecation of inspect.getfullargspec (#99)

### DIFF
--- a/mdp/configuration.py
+++ b/mdp/configuration.py
@@ -4,7 +4,10 @@ from .repo_revision import get_git_revision
 import mdp
 # python 2/3 compatibility
 try:
-    from inspect import getfullargspec as getargs
+    # Migrate to signature as recommended in
+    # https://docs.python.org/3/library/inspect.html#inspect.getfullargspec
+    from inspect import signature
+    getargs = lambda func: (signature(func)._parameters, None)
 except ImportError:
     from inspect import getargspec as getargs
 import tempfile


### PR DESCRIPTION
inspect.getfullargspec is deprecated (see https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) and does not support numpy_linalg.eigh for numpy >= 1.25  (see #99)