### PR TITLE
FIX: compatibility with 32bit arches

### DIFF
--- a/mdp/utils/routines.py
+++ b/mdp/utils/routines.py
@@ -293,7 +293,7 @@ def get_dtypes(typecodes_key, _safe=True):
 
 
 _UNSAFE_DTYPES = [numx.dtype(d).type for d in
-                  ['float16', 'float128', 'complex256']]
+                  [numx.half, numx.longfloat, numx.longcomplex]]
 
 
 def nongeneral_svd(A, range=None, **kwargs):


### PR DESCRIPTION
For 32bit  arches error occurs:

> Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/usr/src/VNEV/lib/python3/site-packages/mdp/__init__.py", line 131, in <module>
    from . import utils
  File "/usr/src/VNEV/lib/python3/site-packages/mdp/utils/__init__.py", line 6, in <module>
    from .routines import (timediff, refcast, scast, rotate, random_rot,
  File "/usr/src/VNEV/lib/python3/site-packages/mdp/utils/routines.py", line 295, in <module>
    _UNSAFE_DTYPES = [numx.dtype(d).type for d in
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/VNEV/lib/python3/site-packages/mdp/utils/routines.py", line 295, in <listcomp>
    _UNSAFE_DTYPES = [numx.dtype(d).type for d in
                      ^^^^^^^^^^^^^
TypeError: data type 'float128' not understood

This pull request fixes this bag.