### PR TITLE
FIX: removed dependence from top-level packages on subpackages with tests

### DIFF
--- a/bimdp/__init__.py
+++ b/bimdp/__init__.py
@@ -85,7 +85,6 @@ from .biflow import (
 # the inspection stuff is considered a core functionality
 from .inspection import *
 
-from .test import test
 
 from . import nodes
 from . import hinet

--- a/bimdp/test/__init__.py
+++ b/bimdp/test/__init__.py
@@ -1,11 +1,12 @@
 import os
 import mdp
+from mdp.test import test as mdp_test
 
-# wrap the mdp.test function and set the module path to bimdp path
-infodict = mdp.NodeMetaclass._function_infodict(mdp.test)
+# wrap the mdp.test.test function and set the module path to bimdp path
+infodict = mdp.NodeMetaclass._function_infodict(mdp_test)
 idx = infodict["argnames"].index('mod_loc')
 defaults = list(infodict['defaults'])
 defaults[idx] = os.path.dirname(__file__)
 infodict['defaults'] = tuple(defaults)
 
-test = mdp.NodeMetaclass._wrap_function(mdp.test, infodict)
+test = mdp.NodeMetaclass._wrap_function(mdp_test, infodict)

--- a/mdp/__init__.py
+++ b/mdp/__init__.py
@@ -171,7 +171,6 @@ from .classifier_node import (ClassifierNode, ClassifierCumulator)
 from . import nodes
 from . import hinet
 from . import parallel
-from .test import test
 
 
 # explicitly set __all__, mainly needed for epydoc

--- a/setup.py
+++ b/setup.py
@@ -57,15 +57,15 @@ def get_long_description():
 
 class MDPTest(_test):
     def run_tests(self):
-        import mdp
-        import bimdp
+        from mdp.test import test as mtest
+        from bimdp.test import test as btest
         # Fix random seed here, as we want reproducible failures in
         # automatic builds using "python setup.py test"
         # If the tests are run manually with pytest or
         # using the mdp.test and bimdp.test functions, the seed
         # is not set
-        errno = mdp.test(seed=725021957)
-        errno += bimdp.test(seed=725021957)
+        errno = mtest(seed=725021957)
+        errno += btest(seed=725021957)
         sys.exit(errno)
 
 def setup_package():


### PR DESCRIPTION
I think it's better to remove dependencies from top-level packages (mdp, bimdp) on their test subpackages. This will allow you to stop distribute tests with your main package. By the way, it is bad practice to import tests from top-level packages just to run tests.